### PR TITLE
Add Capital IQ Pro compatibility with multi-dialect formula support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xargs grep -l \"capiq\")",
+      "Bash(ls -la /c/Users/rturpin/OneDrive*)",
+      "Bash(xargs ls -d)",
+      "Bash(git clone https://github.com/nickderobertis/capiq-excel-downloader-py.git .)",
+      "Bash(git init)",
+      "Bash(git remote add origin https://github.com/nickderobertis/capiq-excel-downloader-py.git)",
+      "Bash(git fetch origin)",
+      "Bash(git checkout -b main origin/master)",
+      "Bash(git add -A)",
+      "Bash(git commit -m \"Initial clone of capiq-excel-downloader-py from upstream\" --no-verify)",
+      "Bash(git checkout -b feat/capiq-pro-compat-modernize)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,124 +2,146 @@
 
 ## Project Overview
 
-Python tool that drives Microsoft Excel via COM automation to download data from S&P Capital IQ using the CIQ Excel plugin. Currently being modernized to support **Capital IQ Pro** (SPG/SNL formula families) alongside the legacy CIQ plugin.
+Python tool that drives Microsoft Excel via COM automation to download data from S&P Capital IQ using the CIQ Excel plugin. **Modernized** to support **Capital IQ Pro** (SPG/SNL formula families) alongside the legacy CIQ plugin.
 
 **Modernization plan:** `C:\Users\rturpin\Downloads\capiq-pro-compatibility-modernization-plan.md`
+**Pro plugin docs:** `C:\Claude\Pro_plugin_documentation\` (Tech Guide + User Guide PDFs)
 
 ## Architecture
 
-### Current Package Structure
+### Package Structure
 
 ```
 capiq_excel/
-  __init__.py          # Public API: download_data, download_data_for_capiq_ids
+  __init__.py          # Public API: download_data, download_data_for_capiq_ids,
+                       #   CapiqConfig, FormulaDialect, AddinMode, get_builder, QuerySpec
   main.py              # Orchestrator: create XLSX -> populate via Excel COM -> combine to CSV
-  addin.py             # Loads legacy "S&P Capital IQ Excel Plug-in" (hardcoded name)
-  exceptions.py        # WorkbookClosedException, CapitalIQInactiveException
-  ids.py               # ID resolution: arbitrary IDs -> CIQ IDs via CIQRANGEA
+                       #   Accepts optional CapiqConfig for dialect/mode selection
+  addin.py             # load_capiq(legacy) + load_capiq_addin(detect runtime, load best)
+  config.py            # CapiqConfig, FormulaDialect/AddinMode/RefreshScope enums,
+                       #   FormulaOptions with to_spg_options_string()
+  cli.py               # CLI entry: capiq status|detect-addins|download|doctor
+  exceptions.py        # Exception classes (legacy + new taxonomy)
+  ids.py               # ID resolution: arbitrary IDs -> CIQ IDs (builder-aware)
   fileops.py           # Failed-file management (move to failed folder)
   combine.py           # Combine per-company XLSX results into single CSV
+  runtime/
+    addin_detection.py # RuntimeProfile, detect_runtime(), load_best_addin(),
+                       #   registry checks (SNL Office keys, CIQ compat toggle)
+  formulas/
+    __init__.py        # get_builder(dialect) factory
+    base.py            # QuerySpec (canonical query), DialectBuilder ABC
+    ciq_builder.py     # CiqBuilder: CIQ(), CIQRANGE() (ID lookup via CIQ)
+    spg_builder.py     # SpgBuilder: SPG(), SPGRangeV(), SPGTable()
+    snl_builder.py     # SnlBuilder: SNLData(), SNLMarkets(), SNLTable(),
+                       #   SNLQuery(), SNLDefinition(), SNLConvert()
+  refresh/
+    engine.py          # refresh_and_wait() with VBA Application.Run for Pro,
+                       #   expanded error/pending token detection
   workbook/
-    commands.py        # Formula generators: CIQRANGE, CIQRANGEA (legacy CIQ only)
-    create.py          # Create XLSX workbooks pre-filled with CIQ formulas
-    wait.py            # Poll Excel for CIQ result readiness (cell A2 heuristic)
+    commands.py        # Builder-aware factories (make_*_command) + legacy CIQ functions
+    create.py          # Create XLSX workbooks (accepts optional DialectBuilder)
+    wait.py            # Legacy cell-A2 polling (used when no config provided)
     populate/
-      main.py          # Open XLSX in Excel, wait for CIQ refresh, save results
-      extract.py       # Extract data from CIQ formula cells (financial + market)
+      main.py          # Open XLSX in Excel, refresh (legacy or Pro), save results
+      extract.py       # Extract data from formula cells (financial + market)
       replace.py       # Write aligned DataFrame back to worksheet
   downloader/
     tools.py           # Batch file processing with retry/timeout/Excel restart
+                       #   (threads config through for Pro-aware detection)
     timeout.py         # ThreadPool-based timeout wrapper
   tools/
-    dates.py           # Date helpers for CIQ formula period calculation
+    dates.py           # Date helpers (pandas freq compat: Q->QE, Y->YE)
     ext_pandas.py      # CSV append utilities, date parsing, DataFrame helpers
 ```
 
-### External Dependencies (COM/Windows)
-
-- `exceldriver` - Excel COM automation (start/attach/restart Excel, add-in loading, workbook creation, column utilities)
-- `processfiles` - File tracking for batch processing (`FileProcessTracker`)
-- `pypiwin32` / `pythoncom` / `win32com` - Windows COM interop
-- `openpyxl` - XLSX creation (offline, before Excel opens them)
-- `pandas` - Data manipulation and CSV I/O
-- `xlrd` - Legacy Excel reading
-
 ### Data Flow
 
-1. **Create phase** (`workbook/create.py`): Generate XLSX files with CIQ formulas in cells (one per company)
-2. **Populate phase** (`downloader/tools.py` -> `workbook/populate/main.py`): Open each XLSX in Excel via COM, CIQ plugin evaluates formulas, wait for results, save
-3. **Combine phase** (`combine.py`): Read all populated XLSX files, merge into single CSV output
+1. **Config** (`CapiqConfig.from_env()` or explicit) -> resolve dialect
+2. **Build formulas** (`get_builder(dialect)` -> `make_*_command(builder)`)
+3. **Create XLSX** (`create.py` fills cells with dialect-appropriate formulas)
+4. **Populate** (Open in Excel via COM -> plugin evaluates -> refresh engine waits)
+5. **Combine** (Extract results into CSV)
 
-### Key Patterns
+### Formula Dialect Differences
 
-- COM operations require `pythoncom.CoInitialize()` per thread
-- Excel is restarted every 500 workbooks to work around memory leaks
-- Failed files are moved to a `failed/` subfolder for retry
-- Market data items produce unaligned date axes (each cell has its own date in the formula); extraction realigns them via `extract.py`
+| Feature | CIQ (Legacy) | SPG (Pro) | SNL (Pro) |
+|---|---|---|---|
+| Single value | `=CIQ(id, metric)` | `=SPG(id, metric, period, opts)` | `=SNLData(dataset, id, field, key)` |
+| Range | `=CIQRANGE(id, metric, period...)` | `=SPGRangeV(id, metric, begin, end, opts)` | `=SNLMarkets(id, field, key, start, end)` |
+| Table | _(none)_ | `=SPGTable(ids, metrics, periods, opts)` | `=SNLTable(dataset, ids, fields, keys, opts)` |
+| ID lookup | `=CIQ(search, "IQ_COMPANY_ID")` | `=SPG(search, field)` | `=SNLData(1, search, field)` |
+| Period syntax | `IQ_FQ - 80` (relative) | `FQ-80`, `FY2020`, `FQ12020` | `2013Q2`, `MRQ`, `[MRQ-1]` |
+| Options | positional args | `"Curr=USD,Mag=Millions"` | `"Curr=USD,Mag=Millions"` |
 
-## Modernization Target (Phased)
+### Pro Refresh Commands (VBA via Application.Run)
 
-### Phase 0: Branching + Feature Flags
-- Feature flags: `formula_dialect` (auto|ciq|spg), `addin_mode` (auto|legacy|pro), `refresh_scope`
-- Existing behavior preserved under `ciq/legacy` defaults
+- Selected cells: `SNLxlAddin.xla!RefreshActiveCells`
+- Entire sheet: `SNLxlAddin.xla!RefreshSheet`
+- All sheets: `SNLxlAddin.xla!RefreshWorkbook`
 
-### Phase 1: Add-In Discovery + Compatibility Layer
-- New: `capiq_excel/runtime/addin_detection.py` - detect legacy vs Pro add-ins
-- Replace hardcoded `load_capiq()` with `load_best_addin()` with fallback
-- Startup diagnostics (Excel version, add-in profile, selected mode)
+### In-Cell Status Tokens
 
-### Phase 2: Formula Dialect Abstraction
-- New: `capiq_excel/formulas/{base,ciq_builder,spg_builder}.py`
-- `QuerySpec` canonical input -> dialect-specific formula output
-- CIQ builder: `CIQ()`, `CIQRANGE()`, `CIQRANGEA()`
-- SPG builder: `SPG()`, `SPGRangeV()`, `SPGTable()`, `SNL*()`
+- **Pending:** `#REFRESH`, `#PEND`
+- **Hard errors:** `#ERROR`, `#INVALID COMPANY ID`, `#INVALID METRIC NAME`, `#INVALID FUNCTION PARAMETER`, `#OUTSIDE SUBSCRIPTION`, `KEYERROR`, `DEFUNCT`, `InvalidCurrency`, `InvalidMagnitude`, `InvalidConvMethod`, `#NAME`
+- **Legacy errors:** `ciqinactive`, `refresh`
 
-### Phase 3: Refresh Engine
-- New: `capiq_excel/refresh/engine.py`
-- Replace cell-A2 heuristic with strategy-based completion checks
-- Batch sequencing, throttling, dependency-aware refresh
+### Registry Keys (Pro)
 
-### Phase 4: Config + Settings
-- New: `capiq_excel/config.py` - dataclass/pydantic config model
-- Registry/env integration for Windows settings
-- CLI commands: `capiq status`, `capiq detect-addins`, `capiq download`, `capiq doctor`
+- Settings: `HKCU\Software\SNL Financial\SNL Office`
+- Load: `HKCU\Software\Microsoft\Office\Excel\Addins\SNL.Clients.Office.Excel.ExcelAddIn\LoadBehavior`
+- CIQ compat toggle: under SNL Office key (v21.08+)
+- Logs: `%LocalAppData%\SPGMI`
 
-### Phase 5: Reliability + Observability
-- Structured logging with run/file IDs
-- Error taxonomy: `AddinNotFoundError`, `DialectUnsupportedError`, `AuthSessionError`, `RefreshTimeoutError`, `FormulaValidationError`
-- Diagnostics bundle export
+## External Dependencies
 
-### Phase 6: Packaging
-- Migrate to `pyproject.toml`
-- Pin Windows COM dependencies
-- CI: unit tests in CI, integration tests gated on Windows+Excel
+- `exceldriver` - Excel COM automation
+- `processfiles` - Batch file tracking
+- `pypiwin32` / `pythoncom` / `win32com` - Windows COM interop
+- `openpyxl` - XLSX creation
+- `pandas` - Data manipulation
+- `xlrd` - Legacy Excel reading
 
 ## Conventions
 
-- Python 3.10+ target (modernization)
+- Python 3.10+ target
 - Type hints on all new code
-- Dataclasses for config and data structures (pydantic optional)
-- `pytest` for testing
-- Formula output must be snapshot-testable (string comparison)
+- Dataclasses for config and data structures
+- `pytest` for testing; formula output is snapshot-testable (string comparison)
 - All COM interaction behind abstraction layers
-- Feature flags control dialect/mode selection; defaults preserve legacy behavior
-- New modules go under clear subdirectories: `runtime/`, `formulas/`, `refresh/`
+- Feature flags control dialect/mode; defaults preserve legacy behavior
+- Builder-aware command factories (`make_*_command(builder)`) alongside legacy functions
 
 ## Commands
 
 ```bash
-# Run tests (requires Windows + Excel + CIQ plugin for integration tests)
-pytest test/
+# Run unit tests (no Excel/COM required)
+python -m pytest test/test_config.py test/test_formulas.py test/test_smoke.py -v
 
-# Install in development mode
-pip install -e .
+# Run all tests (requires Windows + Excel + CIQ plugin for integration)
+python -m pytest test/ -v
+
+# CLI
+capiq status          # Show config from env vars
+capiq detect-addins   # Start Excel, detect installed add-ins
+capiq download --ids MSFT AAPL --financial-items IQ_TOTAL_REV --dialect spg
+capiq doctor          # Check environment health
 ```
 
-## Important Notes
+## Key Notes
 
-- This is a Windows-only tool (COM automation with Excel)
-- The legacy CIQ add-in name is exactly: `S&P Capital IQ Excel Plug-in`
-- CIQ formulas: `CIQ()`, `CIQRANGE()`, `CIQRANGEA()` - use relative periods like `IQ_FQ - 80`
-- Market data formulas use absolute date strings instead of relative periods
-- The `exceldriver` package provides: `load_addin()`, `_start_excel_with_addins_and_attach()`, `_restart_excel_with_addins_and_attach()`, `get_workbook_and_worksheet()`, `excel_cols()`
-- `processfiles.FileProcessTracker` manages which files have been processed in a batch
+- Windows-only tool (COM automation with Excel)
+- Legacy CIQ add-in name: `S&P Capital IQ Excel Plug-in`
+- Pro add-in ProgID: `SNL.Clients.Office.Excel.ExcelAddIn` (display name: `S&P Cap IQ Pro Excel Add-In`)
+- Pro UDF/refresh XLA: `SNLxlAddin.xla` (installed at `%ProgramFiles(x86)%\SNL Financial\SNLxl`)
+- CIQ compat in Pro: toggleable at install and post-install (Settings UI)
+- When CIQ compat is enabled, Pro handles CIQ formula refresh — separate CIQ add-in not needed
+- `tools/dates.py` maps `Q->QE`, `Y->YE` for pandas 3.x compatibility
+- All public functions accept optional `config: CapiqConfig` — omitting it preserves legacy behavior
+- `test_download.py` is an integration test requiring live Excel + CIQ plugin
+- **CRITICAL**: Excel must be launched via subprocess (not `Dispatch()`) for UDFs to register — use `exceldriver._start_excel_with_addins_and_attach()`
+- In Pro CIQ compat mode: `CIQ()` and `CIQRANGE()` work; `CIQRANGEA()` does NOT (returns function name as string)
+- CIQ builder uses `=CIQ(search,"IQ_COMPANY_ID")` for ID lookup (not CIQRANGEA)
+- CIQ compat registry: `DisableCIQUDF = 0` means CIQ is ENABLED (inverted logic)
+- SPG formulas require different metric names/ID formats than CIQ — not yet fully mapped
+- COM error `-2146826259` = `#NAME?` (UDF not registered); `-2146826273` = `#VALUE!`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# capiq-excel-downloader-py
+
+## Project Overview
+
+Python tool that drives Microsoft Excel via COM automation to download data from S&P Capital IQ using the CIQ Excel plugin. Currently being modernized to support **Capital IQ Pro** (SPG/SNL formula families) alongside the legacy CIQ plugin.
+
+**Modernization plan:** `C:\Users\rturpin\Downloads\capiq-pro-compatibility-modernization-plan.md`
+
+## Architecture
+
+### Current Package Structure
+
+```
+capiq_excel/
+  __init__.py          # Public API: download_data, download_data_for_capiq_ids
+  main.py              # Orchestrator: create XLSX -> populate via Excel COM -> combine to CSV
+  addin.py             # Loads legacy "S&P Capital IQ Excel Plug-in" (hardcoded name)
+  exceptions.py        # WorkbookClosedException, CapitalIQInactiveException
+  ids.py               # ID resolution: arbitrary IDs -> CIQ IDs via CIQRANGEA
+  fileops.py           # Failed-file management (move to failed folder)
+  combine.py           # Combine per-company XLSX results into single CSV
+  workbook/
+    commands.py        # Formula generators: CIQRANGE, CIQRANGEA (legacy CIQ only)
+    create.py          # Create XLSX workbooks pre-filled with CIQ formulas
+    wait.py            # Poll Excel for CIQ result readiness (cell A2 heuristic)
+    populate/
+      main.py          # Open XLSX in Excel, wait for CIQ refresh, save results
+      extract.py       # Extract data from CIQ formula cells (financial + market)
+      replace.py       # Write aligned DataFrame back to worksheet
+  downloader/
+    tools.py           # Batch file processing with retry/timeout/Excel restart
+    timeout.py         # ThreadPool-based timeout wrapper
+  tools/
+    dates.py           # Date helpers for CIQ formula period calculation
+    ext_pandas.py      # CSV append utilities, date parsing, DataFrame helpers
+```
+
+### External Dependencies (COM/Windows)
+
+- `exceldriver` - Excel COM automation (start/attach/restart Excel, add-in loading, workbook creation, column utilities)
+- `processfiles` - File tracking for batch processing (`FileProcessTracker`)
+- `pypiwin32` / `pythoncom` / `win32com` - Windows COM interop
+- `openpyxl` - XLSX creation (offline, before Excel opens them)
+- `pandas` - Data manipulation and CSV I/O
+- `xlrd` - Legacy Excel reading
+
+### Data Flow
+
+1. **Create phase** (`workbook/create.py`): Generate XLSX files with CIQ formulas in cells (one per company)
+2. **Populate phase** (`downloader/tools.py` -> `workbook/populate/main.py`): Open each XLSX in Excel via COM, CIQ plugin evaluates formulas, wait for results, save
+3. **Combine phase** (`combine.py`): Read all populated XLSX files, merge into single CSV output
+
+### Key Patterns
+
+- COM operations require `pythoncom.CoInitialize()` per thread
+- Excel is restarted every 500 workbooks to work around memory leaks
+- Failed files are moved to a `failed/` subfolder for retry
+- Market data items produce unaligned date axes (each cell has its own date in the formula); extraction realigns them via `extract.py`
+
+## Modernization Target (Phased)
+
+### Phase 0: Branching + Feature Flags
+- Feature flags: `formula_dialect` (auto|ciq|spg), `addin_mode` (auto|legacy|pro), `refresh_scope`
+- Existing behavior preserved under `ciq/legacy` defaults
+
+### Phase 1: Add-In Discovery + Compatibility Layer
+- New: `capiq_excel/runtime/addin_detection.py` - detect legacy vs Pro add-ins
+- Replace hardcoded `load_capiq()` with `load_best_addin()` with fallback
+- Startup diagnostics (Excel version, add-in profile, selected mode)
+
+### Phase 2: Formula Dialect Abstraction
+- New: `capiq_excel/formulas/{base,ciq_builder,spg_builder}.py`
+- `QuerySpec` canonical input -> dialect-specific formula output
+- CIQ builder: `CIQ()`, `CIQRANGE()`, `CIQRANGEA()`
+- SPG builder: `SPG()`, `SPGRangeV()`, `SPGTable()`, `SNL*()`
+
+### Phase 3: Refresh Engine
+- New: `capiq_excel/refresh/engine.py`
+- Replace cell-A2 heuristic with strategy-based completion checks
+- Batch sequencing, throttling, dependency-aware refresh
+
+### Phase 4: Config + Settings
+- New: `capiq_excel/config.py` - dataclass/pydantic config model
+- Registry/env integration for Windows settings
+- CLI commands: `capiq status`, `capiq detect-addins`, `capiq download`, `capiq doctor`
+
+### Phase 5: Reliability + Observability
+- Structured logging with run/file IDs
+- Error taxonomy: `AddinNotFoundError`, `DialectUnsupportedError`, `AuthSessionError`, `RefreshTimeoutError`, `FormulaValidationError`
+- Diagnostics bundle export
+
+### Phase 6: Packaging
+- Migrate to `pyproject.toml`
+- Pin Windows COM dependencies
+- CI: unit tests in CI, integration tests gated on Windows+Excel
+
+## Conventions
+
+- Python 3.10+ target (modernization)
+- Type hints on all new code
+- Dataclasses for config and data structures (pydantic optional)
+- `pytest` for testing
+- Formula output must be snapshot-testable (string comparison)
+- All COM interaction behind abstraction layers
+- Feature flags control dialect/mode selection; defaults preserve legacy behavior
+- New modules go under clear subdirectories: `runtime/`, `formulas/`, `refresh/`
+
+## Commands
+
+```bash
+# Run tests (requires Windows + Excel + CIQ plugin for integration tests)
+pytest test/
+
+# Install in development mode
+pip install -e .
+```
+
+## Important Notes
+
+- This is a Windows-only tool (COM automation with Excel)
+- The legacy CIQ add-in name is exactly: `S&P Capital IQ Excel Plug-in`
+- CIQ formulas: `CIQ()`, `CIQRANGE()`, `CIQRANGEA()` - use relative periods like `IQ_FQ - 80`
+- Market data formulas use absolute date strings instead of relative periods
+- The `exceldriver` package provides: `load_addin()`, `_start_excel_with_addins_and_attach()`, `_restart_excel_with_addins_and_attach()`, `get_workbook_and_worksheet()`, `excel_cols()`
+- `processfiles.FileProcessTracker` manages which files have been processed in a batch

--- a/capiq_excel/__init__.py
+++ b/capiq_excel/__init__.py
@@ -1,8 +1,19 @@
 """
 A tool to drive Excel using the Capital IQ plugin to download Capital IQ data. Useful for downloading
 large data sets from Capital IQ.
+
+Supports both the legacy CIQ plugin and Capital IQ Pro (SPG/SNL).
 """
 from capiq_excel.main import (
     download_data,
     download_data_for_capiq_ids
 )
+from capiq_excel.config import (
+    CapiqConfig,
+    FormulaDialect,
+    AddinMode,
+    RefreshScope,
+    FormulaOptions,
+)
+from capiq_excel.formulas import get_builder
+from capiq_excel.formulas.base import QuerySpec, DialectBuilder

--- a/capiq_excel/addin.py
+++ b/capiq_excel/addin.py
@@ -1,6 +1,57 @@
+"""
+Add-in loading — unified entry point for legacy and Pro modes.
+
+The legacy load_capiq() is preserved for backward compatibility.
+New code should use load_capiq_addin() which respects the runtime
+profile and config.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
 from exceldriver.addin import load_addin
 
+from capiq_excel.config import AddinMode, CapiqConfig
+from capiq_excel.runtime.addin_detection import (
+    RuntimeProfile,
+    detect_runtime,
+    load_best_addin,
+    log_startup_diagnostics,
+)
+
+logger = logging.getLogger(__name__)
+
+
 def load_capiq(excel):
+    """Legacy entry point — loads the hardcoded CIQ add-in name.
+
+    Preserved for backward compatibility when running in legacy mode.
+    """
     return load_addin(excel, 'S&P Capital IQ Excel Plug-in')
 
 
+def load_capiq_addin(excel, config: Optional[CapiqConfig] = None) -> tuple[RuntimeProfile, str]:
+    """Detect the runtime environment and load the best available add-in.
+
+    Args:
+        excel: COM Excel.Application instance.
+        config: Optional config; defaults to CapiqConfig.from_env().
+
+    Returns:
+        (profile, addin_name) tuple.
+    """
+    if config is None:
+        config = CapiqConfig.from_env()
+
+    profile = detect_runtime(excel)
+    log_startup_diagnostics(profile, config)
+
+    # In legacy mode, use the original hardcoded loader for maximum compat
+    if config.addin_mode == AddinMode.LEGACY:
+        logger.info("Using legacy add-in loader")
+        load_capiq(excel)
+        return profile, "S&P Capital IQ Excel Plug-in"
+
+    addin_name = load_best_addin(excel, config.addin_mode, profile)
+    return profile, addin_name

--- a/capiq_excel/cli.py
+++ b/capiq_excel/cli.py
@@ -1,0 +1,251 @@
+"""
+CLI entry point for capiq-excel.
+
+Usage:
+    capiq status            Show detected runtime profile and config
+    capiq detect-addins     Detect installed add-ins (requires Excel)
+    capiq download          Run the data download pipeline
+    capiq doctor            Run diagnostics and check environment health
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from typing import Optional
+
+from capiq_excel.config import CapiqConfig, FormulaDialect, AddinMode
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="capiq",
+        description="Capital IQ Excel data downloader CLI",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true",
+        help="Enable verbose/debug logging",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    # --- status ---
+    sub.add_parser("status", help="Show current config and environment info")
+
+    # --- detect-addins ---
+    sub.add_parser("detect-addins", help="Detect installed Capital IQ add-ins (starts Excel)")
+
+    # --- download ---
+    dl = sub.add_parser("download", help="Run the data download pipeline")
+    dl.add_argument("--ids", nargs="+", help="Company identifiers (tickers, CUSIPs, etc.)")
+    dl.add_argument("--ids-file", help="Path to file with one identifier per line")
+    dl.add_argument("--financial-items", nargs="+", help="Financial data items (e.g. IQ_TOTAL_REVENUE)")
+    dl.add_argument("--market-items", nargs="+", help="Market data items (e.g. IQ_CLOSEPRICE)")
+    dl.add_argument("--outpath", default="capiq data.csv", help="Output CSV path")
+    dl.add_argument("--dialect", choices=["auto", "ciq", "spg"], default="auto",
+                    help="Formula dialect to use")
+    dl.add_argument("--addin-mode", choices=["auto", "legacy", "pro"], default="auto",
+                    help="Add-in mode")
+    dl.add_argument("--freq", choices=["Q", "Y"], default="Q", help="Data frequency")
+    dl.add_argument("--num-periods", type=int, default=80, help="Number of periods")
+    dl.add_argument("--timeout", type=int, default=240, help="Timeout per file (seconds)")
+
+    # --- doctor ---
+    sub.add_parser("doctor", help="Run environment diagnostics")
+
+    args = parser.parse_args(argv)
+
+    # Configure logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    if args.command == "status":
+        return _cmd_status()
+    elif args.command == "detect-addins":
+        return _cmd_detect_addins()
+    elif args.command == "download":
+        return _cmd_download(args)
+    elif args.command == "doctor":
+        return _cmd_doctor()
+    else:
+        parser.print_help()
+        return 1
+
+
+def _cmd_status() -> int:
+    """Show current config from environment."""
+    config = CapiqConfig.from_env()
+    print("Capital IQ Excel Downloader — Current Configuration")
+    print("=" * 52)
+    print(f"  Formula dialect:  {config.formula_dialect.value}")
+    print(f"  Add-in mode:      {config.addin_mode.value}")
+    print(f"  Refresh scope:    {config.refresh_scope.value}")
+    print(f"  Frequency:        {config.freq}")
+    print(f"  Num periods:      {config.num_periods}")
+    print(f"  Timeout:          {config.retry.timeout_seconds}s")
+    print(f"  Max retries:      {config.retry.max_retries}")
+    print(f"  Restart interval: {config.retry.restart_interval}")
+    opts = config.formula_options.to_spg_options_string()
+    print(f"  Formula options:  {opts or '(none)'}")
+    print()
+    print("Environment variables:")
+    import os
+    for var in ("CAPIQ_FORMULA_DIALECT", "CAPIQ_ADDIN_MODE", "CAPIQ_REFRESH_SCOPE",
+                "CAPIQ_FREQ", "CAPIQ_NUM_PERIODS", "CAPIQ_TIMEOUT", "CAPIQ_MAX_RETRIES",
+                "CAPIQ_RESTART_INTERVAL"):
+        val = os.environ.get(var)
+        print(f"  {var} = {val or '(not set)'}")
+    return 0
+
+
+def _cmd_detect_addins() -> int:
+    """Detect installed add-ins by starting Excel and scanning COM."""
+    print("Starting Excel and scanning for Capital IQ add-ins...")
+    try:
+        from exceldriver.tools import _start_excel_with_addins_and_attach
+        from capiq_excel.runtime.addin_detection import detect_runtime
+    except ImportError as e:
+        print(f"Error: Required packages not available: {e}")
+        print("This command requires pypiwin32 and exceldriver to be installed.")
+        return 1
+
+    try:
+        excel = _start_excel_with_addins_and_attach()
+        profile = detect_runtime(excel)
+    except Exception as e:
+        print(f"Error: Could not start Excel or detect add-ins: {e}")
+        return 1
+
+    print()
+    print("Runtime Profile")
+    print("=" * 40)
+    print(f"  Excel version:      {profile.excel_version or 'unknown'}")
+    print(f"  Excel bitness:      {profile.excel_bitness or 'unknown'}")
+    print(f"  Add-in mode:        {profile.addin_mode}")
+    print(f"  Legacy add-in:      {profile.legacy_addin_name or '(not found)'}")
+    print(f"  Pro add-in:         {profile.pro_addin_name or '(not found)'}")
+    print(f"  Pro installed:      {profile.pro_installed}")
+    print(f"  Pro load behavior:  {profile.pro_load_behavior}")
+    print(f"  CIQ compat:         {profile.ciq_compat_enabled}")
+    print(f"  Available dialects: {', '.join(sorted(profile.available_dialects)) or '(none)'}")
+    print(f"  Install path:       {profile.install_path or '(unknown)'}")
+    print(f"  Log path:           {profile.log_path or '(unknown)'}")
+    return 0
+
+
+def _cmd_download(args) -> int:
+    """Run the download pipeline."""
+    # Collect company IDs
+    ids = []
+    if args.ids:
+        ids.extend(args.ids)
+    if args.ids_file:
+        try:
+            with open(args.ids_file) as f:
+                ids.extend(line.strip() for line in f if line.strip())
+        except FileNotFoundError:
+            print(f"Error: IDs file not found: {args.ids_file}")
+            return 1
+
+    if not ids:
+        print("Error: No company identifiers provided. Use --ids or --ids-file.")
+        return 1
+
+    financial_items = args.financial_items
+    market_items = args.market_items
+    if not financial_items and not market_items:
+        print("Error: Must provide --financial-items and/or --market-items.")
+        return 1
+
+    config = CapiqConfig.from_env()
+    # Override with CLI arguments
+    config.formula_dialect = FormulaDialect(args.dialect)
+    config.addin_mode = AddinMode(args.addin_mode)
+    config.freq = args.freq
+    config.num_periods = args.num_periods
+    config.retry.timeout_seconds = args.timeout
+
+    from capiq_excel.main import download_data
+
+    try:
+        download_data(
+            company_ids=ids,
+            financial_data_items=financial_items,
+            market_data_items=market_items,
+            data_outpath=args.outpath,
+            config=config,
+            freq=config.freq,
+            num_periods=config.num_periods,
+        )
+        print(f"\nData saved to: {args.outpath}")
+        return 0
+    except Exception as e:
+        print(f"\nError during download: {e}")
+        logging.getLogger(__name__).debug("Download error details:", exc_info=True)
+        return 1
+
+
+def _cmd_doctor() -> int:
+    """Run environment diagnostics."""
+    print("Capital IQ Excel Downloader — Environment Check")
+    print("=" * 50)
+    issues = []
+
+    # Check Python version
+    print(f"\n[1] Python: {sys.version}")
+
+    # Check required packages
+    print("\n[2] Required packages:")
+    for pkg in ("pandas", "openpyxl", "win32com", "pythoncom", "pywintypes",
+                "exceldriver", "processfiles"):
+        try:
+            __import__(pkg)
+            print(f"  {pkg}: OK")
+        except ImportError:
+            print(f"  {pkg}: MISSING")
+            issues.append(f"Package '{pkg}' is not installed")
+
+    # Check config
+    print("\n[3] Configuration:")
+    config = CapiqConfig.from_env()
+    print(f"  Dialect: {config.formula_dialect.value}")
+    print(f"  Mode:    {config.addin_mode.value}")
+
+    # Check registry (Windows only)
+    print("\n[4] Registry (Windows):")
+    try:
+        import winreg
+        from capiq_excel.runtime.addin_detection import _REG_EXCEL_ADDINS, _REG_SNL_OFFICE
+
+        for name, path in [("Excel Add-ins", _REG_EXCEL_ADDINS), ("SNL Office", _REG_SNL_OFFICE)]:
+            try:
+                with winreg.OpenKey(winreg.HKEY_CURRENT_USER, path):
+                    print(f"  {name}: Found")
+            except FileNotFoundError:
+                print(f"  {name}: Not found")
+    except ImportError:
+        print("  winreg: Not available (non-Windows platform)")
+        issues.append("Running on non-Windows platform — COM automation will not work")
+
+    # Summary
+    print(f"\n{'=' * 50}")
+    if issues:
+        print(f"Found {len(issues)} issue(s):")
+        for issue in issues:
+            print(f"  - {issue}")
+        return 1
+    else:
+        print("All checks passed!")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/capiq_excel/config.py
+++ b/capiq_excel/config.py
@@ -1,0 +1,127 @@
+"""
+Central configuration for capiq-excel.
+
+Feature flags and runtime settings that control dialect selection,
+add-in mode, refresh behavior, and formula option defaults.
+
+Config resolution order:
+  1. Explicit arguments passed to functions
+  2. Environment variables (CAPIQ_*)
+  3. Defaults (legacy-compatible)
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class FormulaDialect(Enum):
+    """Which formula family to emit."""
+    AUTO = "auto"
+    CIQ = "ciq"
+    SPG = "spg"
+
+
+class AddinMode(Enum):
+    """Which add-in to target."""
+    AUTO = "auto"
+    LEGACY = "legacy"
+    PRO = "pro"
+
+
+class RefreshScope(Enum):
+    """Granularity of refresh operations."""
+    WORKSHEET = "worksheet"
+    WORKBOOK = "workbook"
+    SELECTION = "selection"
+
+
+@dataclass
+class FormulaOptions:
+    """Default options applied to generated formulas.
+
+    For SPG/SNL functions, these are serialized into an options string like:
+        "Curr=USD,Mag=Millions,ConvMethod=Recommended"
+
+    CIQ formulas don't use this options string format.
+    """
+    currency: Optional[str] = None          # ISO code e.g. "USD", or "RC" for reported
+    magnitude: Optional[str] = None         # "Standard"|"Actuals"|"Thousands"|"Millions"|"Billions"|"Trillions" or "0"|"3"|"6"|"9"|"12"
+    conversion_method: Optional[str] = None # "Recommended" | "MRSpot"
+    null_display: Optional[str] = None      # e.g. "NA", "0", "#NA", "NAZ"
+    terminology: Optional[str] = None       # language code e.g. "en-US", "ja-JP", "zh-CN"
+
+    def to_spg_options_string(self) -> Optional[str]:
+        """Serialize non-None options into SPG/SNL options string format.
+
+        Returns None if no options are set.
+        Example output: "Curr=USD,Mag=Millions,ConvMethod=Recommended"
+        """
+        parts: list[str] = []
+        if self.currency is not None:
+            parts.append(f"Curr={self.currency}")
+        if self.magnitude is not None:
+            parts.append(f"Mag={self.magnitude}")
+        if self.conversion_method is not None:
+            parts.append(f"ConvMethod={self.conversion_method}")
+        if self.null_display is not None:
+            parts.append(f"NullValue={self.null_display}")
+        if self.terminology is not None:
+            parts.append(f"Terminology={self.terminology}")
+        return ",".join(parts) if parts else None
+
+
+@dataclass
+class RetryConfig:
+    """Retry and timeout parameters."""
+    max_retries: int = 3
+    timeout_seconds: int = 240
+    restart_interval: int = 500  # restart Excel every N workbooks
+    retry_delay_seconds: int = 30
+
+
+@dataclass
+class CapiqConfig:
+    """Top-level configuration for a capiq-excel session."""
+
+    # Feature flags (Phase 0)
+    formula_dialect: FormulaDialect = FormulaDialect.AUTO
+    addin_mode: AddinMode = AddinMode.AUTO
+    refresh_scope: RefreshScope = RefreshScope.WORKSHEET
+
+    # Formula defaults
+    freq: str = "Q"
+    num_periods: int = 80
+    formula_options: FormulaOptions = field(default_factory=FormulaOptions)
+
+    # Retry / reliability
+    retry: RetryConfig = field(default_factory=RetryConfig)
+
+    @classmethod
+    def from_env(cls) -> CapiqConfig:
+        """Build config from environment variables, falling back to defaults."""
+        dialect_str = os.environ.get("CAPIQ_FORMULA_DIALECT", "auto").lower()
+        mode_str = os.environ.get("CAPIQ_ADDIN_MODE", "auto").lower()
+        scope_str = os.environ.get("CAPIQ_REFRESH_SCOPE", "worksheet").lower()
+
+        return cls(
+            formula_dialect=FormulaDialect(dialect_str),
+            addin_mode=AddinMode(mode_str),
+            refresh_scope=RefreshScope(scope_str),
+            freq=os.environ.get("CAPIQ_FREQ", "Q"),
+            num_periods=int(os.environ.get("CAPIQ_NUM_PERIODS", "80")),
+            retry=RetryConfig(
+                max_retries=int(os.environ.get("CAPIQ_MAX_RETRIES", "3")),
+                timeout_seconds=int(os.environ.get("CAPIQ_TIMEOUT", "240")),
+                restart_interval=int(os.environ.get("CAPIQ_RESTART_INTERVAL", "500")),
+            ),
+        )
+
+    def resolve_dialect(self, ciq_compat_available: bool = True) -> FormulaDialect:
+        """Resolve AUTO dialect based on runtime detection."""
+        if self.formula_dialect != FormulaDialect.AUTO:
+            return self.formula_dialect
+        # AUTO: prefer CIQ when compatibility mode is available (safe default)
+        return FormulaDialect.CIQ if ciq_compat_available else FormulaDialect.SPG

--- a/capiq_excel/downloader/tools.py
+++ b/capiq_excel/downloader/tools.py
@@ -13,13 +13,25 @@ from processfiles.files import FileProcessTracker
 
 def populate_all_files_in_folder(folder, financial_data_items_dict: Dict[str, str],
                                  market_data_items_dict: Dict[str, str], restart=True, timeout=240,
-                                 run_failed=False,):
+                                 run_failed=False, config=None):
     """
+    Populate all XLSX files in a folder by opening them in Excel and letting
+    the Capital IQ plugin evaluate the formulas.
 
+    When *config* is provided, uses the new refresh engine and runtime detection.
     """
     _validate_populate_inputs(folder, restart, run_failed)
 
     excel = _start_excel_with_addins_and_attach()
+
+    # When config is available, detect runtime and load the right add-in
+    if config is not None:
+        from capiq_excel.addin import load_capiq_addin
+        try:
+            profile, addin_name = load_capiq_addin(excel, config)
+        except Exception as e:
+            print(f'Warning: Could not detect/load add-in ({e}), falling back to default behavior')
+
     failed_folder = get_path_of_failed_folder_add_if_necessary(folder)
 
     if run_failed:
@@ -28,6 +40,10 @@ def populate_all_files_in_folder(folder, financial_data_items_dict: Dict[str, st
         failed_folder = get_path_of_additional_failed_folder_add_if_necessary(folder)
 
     file_tracker = FileProcessTracker(folder=folder, restart=restart, file_types=('xlsx',))
+
+    effective_timeout = timeout
+    if config is not None:
+        effective_timeout = config.retry.timeout_seconds
 
     with ThreadPoolExecutor(max_workers=1) as e:
         for i, file in enumerate(file_tracker.file_generator()):
@@ -38,7 +54,9 @@ def populate_all_files_in_folder(folder, financial_data_items_dict: Dict[str, st
                 file,
                 excel,
                 financial_data_items_dict=financial_data_items_dict,
-                market_data_items_dict=market_data_items_dict
+                market_data_items_dict=market_data_items_dict,
+                config=config,
+                timeout=effective_timeout,
             )
 
             if not successful:
@@ -60,7 +78,8 @@ def _validate_populate_inputs(folder, restart, run_failed):
 
 ### Functions below to assist with multiprocessing/timeout handling
 
-def _try_to_get_result_if_fail_restart_excel(threadpool, i, file, excel, tries_remaining=3, **kwargs):
+def _try_to_get_result_if_fail_restart_excel(threadpool, i, file, excel, tries_remaining=3,
+                                              timeout=300, **kwargs):
 
     if tries_remaining <= 0:
         print(fr'ERROR: Timed out processing {file}. Skipping and moving to "..\failed".')
@@ -69,12 +88,14 @@ def _try_to_get_result_if_fail_restart_excel(threadpool, i, file, excel, tries_r
     # Submit result on threadpool asynchronously
     async_result = threadpool.submit(populate_capiq_for_file, file, excel, index=i + 1, **kwargs)
 
-    # Try to get the result, waiting up to two minutes.
+    # Try to get the result, waiting up to timeout seconds.
     try:
-        excel, successful = async_result.result(timeout=300)
+        excel, successful = async_result.result(timeout=timeout)
     except TimeoutError:
         excel = _restart_excel_with_addins_and_attach()
-        return _try_to_get_result_if_fail_restart_excel(threadpool, i, file, excel, tries_remaining=tries_remaining - 1)
+        return _try_to_get_result_if_fail_restart_excel(threadpool, i, file, excel,
+                                                         tries_remaining=tries_remaining - 1,
+                                                         timeout=timeout, **kwargs)
 
 
     return excel, successful
@@ -87,5 +108,3 @@ def _restart_excel_and_return_false():
 
 def _return_false():
     return False
-
-## END TEMP

--- a/capiq_excel/exceptions.py
+++ b/capiq_excel/exceptions.py
@@ -3,3 +3,26 @@ class WorkbookClosedException(Exception):
 
 class CapitalIQInactiveException(Exception):
     pass
+
+
+# --- New exception taxonomy (Phase 5) ---
+
+class AddinNotFoundError(Exception):
+    """No suitable Capital IQ add-in could be detected or loaded."""
+    pass
+
+class DialectUnsupportedError(Exception):
+    """Requested formula dialect is not available in the current environment."""
+    pass
+
+class AuthSessionError(Exception):
+    """Capital IQ authentication or session is invalid/expired."""
+    pass
+
+class RefreshTimeoutError(Exception):
+    """Workbook refresh did not complete within the allowed timeout."""
+    pass
+
+class FormulaValidationError(Exception):
+    """Generated formula failed validation checks."""
+    pass

--- a/capiq_excel/formulas/__init__.py
+++ b/capiq_excel/formulas/__init__.py
@@ -1,0 +1,32 @@
+"""
+Formula builder factory.
+
+Use get_builder() to obtain the correct DialectBuilder for the resolved dialect.
+"""
+from __future__ import annotations
+
+from capiq_excel.config import FormulaDialect
+from capiq_excel.formulas.base import DialectBuilder, QuerySpec
+from capiq_excel.formulas.ciq_builder import CiqBuilder
+from capiq_excel.formulas.spg_builder import SpgBuilder
+
+_BUILDERS = {
+    FormulaDialect.CIQ: CiqBuilder,
+    FormulaDialect.SPG: SpgBuilder,
+}
+
+
+def get_builder(dialect: FormulaDialect) -> DialectBuilder:
+    """Return a DialectBuilder instance for the given dialect.
+
+    Raises ValueError if dialect is AUTO (must be resolved first).
+    """
+    if dialect == FormulaDialect.AUTO:
+        raise ValueError(
+            "Dialect must be resolved before getting a builder. "
+            "Use config.resolve_dialect() first."
+        )
+    cls = _BUILDERS.get(dialect)
+    if cls is None:
+        raise ValueError(f"No builder registered for dialect: {dialect.value}")
+    return cls()

--- a/capiq_excel/formulas/base.py
+++ b/capiq_excel/formulas/base.py
@@ -1,0 +1,77 @@
+"""
+Formula builder interface and canonical query specification.
+
+All formula generation goes through QuerySpec -> DialectBuilder -> Excel formula string.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Optional
+
+from capiq_excel.config import FormulaOptions
+
+
+@dataclass
+class QuerySpec:
+    """Canonical, dialect-agnostic description of a data query.
+
+    This is the single input shape that all dialect builders consume.
+    Fields map to the union of CIQ, SPG, and SNL function parameters.
+    """
+    identifiers: list[str]
+    metric: str
+    metric_type: str = "financial"  # "financial" | "market" | "ownership" | "estimates" | "id_lookup"
+
+    # Period specification — builders interpret these per-dialect
+    period: Optional[str] = None      # dialect-native period code (e.g. "FQ0", "IQ_FQ - 80", "2013Q2")
+    frequency: str = "Q"             # "Q" | "Y" | "M" | "D" | "W"
+    num_periods: int = 80
+    begin_date: Optional[str] = None  # absolute date string (mm/dd/yyyy) or period code
+    end_date: Optional[str] = None
+
+    # SNL-specific keys (SNLData, SNLMarkets, SNLTable)
+    dataset: Optional[int] = None         # SNL dataset number (e.g. 1=Companies Classic, 266637=Companies)
+    secondary_key: Optional[str] = None   # e.g. fiscal period for financials
+    tertiary_key: Optional[str] = None    # e.g. reporting basis
+
+    # Ownership-specific
+    start_rank: Optional[int] = None
+    end_rank: Optional[int] = None
+
+    # Output control
+    label: Optional[str] = None
+    options: FormulaOptions = field(default_factory=FormulaOptions)
+
+
+class DialectBuilder(ABC):
+    """Abstract base for dialect-specific formula generators."""
+
+    @abstractmethod
+    def build_single_value(self, spec: QuerySpec) -> str:
+        """Build a single-value formula (e.g., CIQ, SPG, SNLData)."""
+        ...
+
+    @abstractmethod
+    def build_range(self, spec: QuerySpec) -> str:
+        """Build a range formula (e.g., CIQRANGE, SPGRangeV, SNLMarkets)."""
+        ...
+
+    @abstractmethod
+    def build_table(self, spec: QuerySpec) -> str:
+        """Build a table formula (e.g., SPGTable, SNLTable).
+
+        Table functions fill a region from a single cell with multiple
+        identifiers and fields.
+        """
+        ...
+
+    @abstractmethod
+    def build_identifier_lookup(self, search_str: str, field_name: str = "IQ_COMPANY_ID_QUICK_MATCH") -> str:
+        """Build an identifier lookup formula."""
+        ...
+
+    @abstractmethod
+    def dialect_name(self) -> str:
+        """Return the dialect identifier (e.g., 'ciq', 'spg', 'snl')."""
+        ...

--- a/capiq_excel/formulas/ciq_builder.py
+++ b/capiq_excel/formulas/ciq_builder.py
@@ -1,0 +1,70 @@
+"""
+Legacy CIQ formula builder.
+
+Generates CIQ(), CIQRANGE(), and CIQRANGEA() formulas matching
+the legacy S&P Capital IQ Excel Plug-in syntax.
+"""
+from __future__ import annotations
+
+from capiq_excel.formulas.base import DialectBuilder, QuerySpec
+from capiq_excel.tools.dates import freq_and_periods_to_begin_date_str, today_as_str
+
+
+class CiqBuilder(DialectBuilder):
+    """Emits legacy CIQ-family formulas."""
+
+    def dialect_name(self) -> str:
+        return "ciq"
+
+    def build_single_value(self, spec: QuerySpec) -> str:
+        label = spec.label or spec.metric
+        return f'=CIQ("{spec.identifiers[0]}", "{spec.metric}")'
+
+    def build_range(self, spec: QuerySpec) -> str:
+        label = spec.label or spec.metric
+
+        if spec.metric_type == "market":
+            return self._build_market_range(spec, label)
+        elif spec.metric_type == "ownership":
+            return self._build_holdings_range(spec, label)
+        else:
+            return self._build_financial_range(spec, label)
+
+    def build_table(self, spec: QuerySpec) -> str:
+        """CIQ does not have a native table function. Falls back to build_range."""
+        return self.build_range(spec)
+
+    def build_identifier_lookup(self, search_str: str, field_name: str = "IQ_COMPANY_ID_QUICK_MATCH") -> str:
+        # CIQ() works in both legacy and Pro compat mode.
+        # CIQRANGEA does NOT work in Pro compat mode (returns function name as string).
+        # Map the _QUICK_MATCH field names to their CIQ() equivalents.
+        ciq_field = field_name
+        if field_name == "IQ_COMPANY_ID_QUICK_MATCH":
+            ciq_field = "IQ_COMPANY_ID"
+        elif field_name == "IQ_COMPANY_NAME_QUICK_MATCH":
+            ciq_field = "IQ_COMPANY_NAME"
+        return f'=CIQ("{search_str}","{ciq_field}")'
+
+    # --- private helpers ---
+
+    def _build_financial_range(self, spec: QuerySpec, label: str) -> str:
+        freq_char = spec.frequency
+        return (
+            f'=CIQRANGE("{spec.identifiers[0]}", "{spec.metric}", '
+            f'IQ_F{freq_char} - {spec.num_periods}, , , , , , "{label}")'
+        )
+
+    def _build_market_range(self, spec: QuerySpec, label: str) -> str:
+        begin = spec.begin_date or freq_and_periods_to_begin_date_str(spec.frequency, spec.num_periods)
+        end = spec.end_date or today_as_str()
+        return (
+            f'=CIQRANGE("{spec.identifiers[0]}", "{spec.metric}", '
+            f'"{begin}", "{end}", , , , , "{label}")'
+        )
+
+    def _build_holdings_range(self, spec: QuerySpec, label: str) -> str:
+        date_str = spec.begin_date or today_as_str()
+        return (
+            f'=CIQRANGE("{spec.identifiers[0]}", "{spec.metric}", '
+            f'1, 50000, "{date_str}", , , , "{label}")'
+        )

--- a/capiq_excel/formulas/snl_builder.py
+++ b/capiq_excel/formulas/snl_builder.py
@@ -1,0 +1,153 @@
+"""
+Legacy SNL formula builder for Capital IQ Pro.
+
+Generates SNLData(), SNLMarkets(), SNLTable(), SNLQuery(), SNLConvert(),
+and SNLDefinition() formulas. These are the SNL-heritage functions that
+coexist with SPG functions in the Capital IQ Pro add-in.
+
+SNL period syntax uses a different format from SPG:
+  - Absolute:  2013Q2, 2012Y, 2014H1, 2012T2 (YTD), 2013L3 (LTM)
+  - Relative:  MRQ, MRY, MRH, YTD, LTM, [MRQ-1], [MRH-2]
+
+SNL datasets are identified by numeric IDs:
+  - 1 = Companies (Classic), 266637 = Companies, 5 = M&A, etc.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from capiq_excel.formulas.base import DialectBuilder, QuerySpec
+
+
+class SnlBuilder(DialectBuilder):
+    """Emits SNL-family formulas for the Capital IQ Pro add-in."""
+
+    def dialect_name(self) -> str:
+        return "snl"
+
+    def build_single_value(self, spec: QuerySpec) -> str:
+        """=SNLData(DataSet, SNLID, FieldID, SecondaryKey, TertiaryKey, Options)"""
+        dataset = spec.dataset or 1
+        identifier = spec.identifiers[0]
+        secondary = spec.secondary_key or ""
+        tertiary = spec.tertiary_key or ""
+        opts = spec.options.to_spg_options_string()
+
+        parts = [str(dataset), f'"{identifier}"', f'"{spec.metric}"']
+
+        if secondary:
+            parts.append(f'"{secondary}"')
+        else:
+            parts.append("")
+
+        if tertiary:
+            parts.append(f'"{tertiary}"')
+        elif opts:
+            parts.append("")  # placeholder so options land in right position
+
+        if opts:
+            parts.append(f'"{opts}"')
+
+        return f'=SNLData({", ".join(parts)})'
+
+    def build_range(self, spec: QuerySpec) -> str:
+        """=SNLMarkets(Display, Entity, FieldID, SecondaryKey, TertiaryKey, StartDate, EndDate, Options)
+
+        SNLMarkets is specifically for market/pricing data with date ranges.
+        For non-market data, falls back to SNLData.
+        """
+        if spec.metric_type != "market":
+            return self.build_single_value(spec)
+
+        identifier = spec.identifiers[0]
+        start = spec.begin_date or ""
+        end = spec.end_date or ""
+        secondary = spec.secondary_key or ""
+        tertiary = spec.tertiary_key or ""
+        opts = spec.options.to_spg_options_string()
+
+        parts = [
+            f'"{identifier}"',
+            f'"{spec.metric}"',
+        ]
+
+        if secondary:
+            parts.append(f'"{secondary}"')
+        else:
+            parts.append("")
+
+        if tertiary:
+            parts.append(f'"{tertiary}"')
+        else:
+            parts.append("")
+
+        parts.append(f'"{start}"')
+        if end:
+            parts.append(f'"{end}"')
+
+        if opts:
+            # Pad to the options position if end was omitted
+            if not end:
+                parts.append("")
+            parts.append(f'"{opts}"')
+
+        return f'=SNLMarkets({", ".join(parts)})'
+
+    def build_table(self, spec: QuerySpec) -> str:
+        """=SNLTable(DataSet, SNLIDRange, FieldIDRange, SecondaryKeyRange, Options)
+
+        In real use, ID/Field/Key ranges are cell references. For formula
+        generation we emit literal values.
+        """
+        dataset = spec.dataset or 1
+        identifier = spec.identifiers[0]
+        secondary = spec.secondary_key or ""
+        opts = spec.options.to_spg_options_string()
+
+        parts = [str(dataset), f'"{identifier}"', f'"{spec.metric}"']
+
+        if secondary:
+            parts.append(f'"{secondary}"')
+        elif opts:
+            parts.append("")
+
+        if opts:
+            parts.append(f'"{opts}"')
+
+        return f'=SNLTable({", ".join(parts)})'
+
+    def build_identifier_lookup(self, search_str: str, field_name: str = "IQ_COMPANY_ID_QUICK_MATCH") -> str:
+        """SNL identifier lookup via SNLData against Companies dataset."""
+        return f'=SNLData(1, "{search_str}", "{field_name}")'
+
+    def build_query(self, query_name: str, field_range: Optional[str] = None,
+                    opts: Optional[str] = None) -> str:
+        """=SNLQuery(QueryName, FieldIDRange, Options)
+
+        Reruns a saved screen/project by name.
+        """
+        parts = [f'"{query_name}"']
+        if field_range:
+            parts.append(field_range)  # cell reference, not quoted
+        elif opts:
+            parts.append("")
+        if opts:
+            parts.append(f'"{opts}"')
+        return f'=SNLQuery({", ".join(parts)})'
+
+    def build_definition(self, dataset: int, field_id: str,
+                         terminology: Optional[str] = None) -> str:
+        """=SNLDefinition(DataSet, FieldID, Terminology)"""
+        parts = [str(dataset), f'"{field_id}"']
+        if terminology:
+            parts.append(f'"{terminology}"')
+        return f'=SNLDefinition({", ".join(parts)})'
+
+    def build_convert(self, from_dataset: int, id_range: str,
+                      to_dataset: int) -> str:
+        """=SNLConvert(FromDataSet, SNLIDRange, ToDataSet)
+
+        Converts entities from one dataset to another (e.g. companies -> branches).
+        id_range is typically a cell reference.
+        """
+        return f'=SNLConvert({from_dataset}, {id_range}, {to_dataset})'

--- a/capiq_excel/formulas/spg_builder.py
+++ b/capiq_excel/formulas/spg_builder.py
@@ -1,0 +1,127 @@
+"""
+Capital IQ Pro SPG formula builder.
+
+Generates SPG(), SPGRangeV(), and SPGTable() formulas for the
+Capital IQ Pro Office add-in.
+
+SPG period syntax uses native period codes:
+  - Relative fiscal:   FY0, FY-1, FQ0, FQ-1, FH0, LTM, YTD, NTM
+  - Relative calendar:  CY0, CY-1, CQ0, CQ-1
+  - Absolute fiscal:   FY2020, FQ12020, FH12020, LTM22017, YTD22017
+  - Absolute calendar:  CY2020, CQ12020
+
+Options are passed as a key=value string:
+  "Curr=USD,Mag=Millions,ConvMethod=Recommended"
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from capiq_excel.formulas.base import DialectBuilder, QuerySpec
+
+
+# Map our canonical frequency codes to SPG period prefix
+_FREQ_TO_PERIOD_PREFIX = {
+    "Q": "FQ",
+    "Y": "FY",
+}
+
+
+class SpgBuilder(DialectBuilder):
+    """Emits Capital IQ Pro SPG-family formulas."""
+
+    def dialect_name(self) -> str:
+        return "spg"
+
+    def build_single_value(self, spec: QuerySpec) -> str:
+        """=SPG(Identifier, Metric, Period, AsOfDate, Options)"""
+        identifier = spec.identifiers[0]
+        period = spec.period or _default_relative_period(spec.frequency)
+        opts = spec.options.to_spg_options_string()
+
+        parts = [
+            f'"{identifier}"',
+            f'"{spec.metric}"',
+            f'"{period}"',
+        ]
+        # Add options at the end if present
+        if opts:
+            parts.append("")  # skip AsOfDate
+            parts.append(f'"{opts}"')
+
+        return f'=SPG({", ".join(parts)})'
+
+    def build_range(self, spec: QuerySpec) -> str:
+        """=SPGRangeV(Identifier, Metric, BeginPeriod, EndPeriod, Options)"""
+        identifier = spec.identifiers[0]
+        label = spec.label or spec.metric
+        opts = spec.options.to_spg_options_string()
+
+        begin = spec.begin_date or _begin_period_code(spec.frequency, spec.num_periods)
+        end = spec.end_date or _end_period_code(spec.frequency)
+
+        parts = [
+            f'"{identifier}"',
+            f'"{spec.metric}"',
+            f'"{begin}"',
+            f'"{end}"',
+        ]
+        if opts:
+            parts.append(f'"{opts}"')
+
+        return f'=SPGRangeV({", ".join(parts)})'
+
+    def build_table(self, spec: QuerySpec) -> str:
+        """=SPGTable(IdentifierRange, MetricRange, PeriodRange, Options)
+
+        SPGTable fills a region from a single cell with data for multiple
+        identifiers x fields x periods. The cell ranges for identifiers,
+        metrics, and periods are typically cell references in real use.
+        For formula generation, we emit the literal values.
+        """
+        identifier = spec.identifiers[0]
+        period = spec.period or _default_relative_period(spec.frequency)
+        opts = spec.options.to_spg_options_string()
+
+        parts = [
+            f'"{identifier}"',
+            f'"{spec.metric}"',
+            f'"{period}"',
+        ]
+        if opts:
+            parts.append(f'"{opts}"')
+
+        return f'=SPGTable({", ".join(parts)})'
+
+    def build_identifier_lookup(self, search_str: str, field_name: str = "IQ_COMPANY_ID_QUICK_MATCH") -> str:
+        """SPG identifier lookup — same as single-value with ID metric."""
+        return f'=SPG("{search_str}", "{field_name}")'
+
+
+# --- period code helpers ---
+
+def _default_relative_period(frequency: str) -> str:
+    """Return the 'latest' relative period code for a frequency.
+
+    e.g. Q -> FQ0, Y -> FY0
+    """
+    prefix = _FREQ_TO_PERIOD_PREFIX.get(frequency, "FQ")
+    return f"{prefix}0"
+
+
+def _begin_period_code(frequency: str, num_periods: int) -> str:
+    """Generate a relative begin-period code.
+
+    e.g. frequency=Q, num_periods=80 -> "FQ-80"
+         frequency=Y, num_periods=20 -> "FY-20"
+    """
+    prefix = _FREQ_TO_PERIOD_PREFIX.get(frequency, "FQ")
+    return f"{prefix}-{num_periods}"
+
+
+def _end_period_code(frequency: str) -> str:
+    """Generate the 'current' end-period code.
+
+    e.g. Q -> FQ0, Y -> FY0
+    """
+    return _default_relative_period(frequency)

--- a/capiq_excel/ids.py
+++ b/capiq_excel/ids.py
@@ -8,7 +8,8 @@ from capiq_excel.workbook.populate.main import populate_capiq_ids_for_file
 from capiq_excel.workbook.create import create_all_xlsx_with_id_commands
 
 
-def download_capiq_ids(ids: Sequence[str], outpath: str = 'capiq ids.csv', folder: str = 'in_process_ids') -> List[str]:
+def download_capiq_ids(ids: Sequence[str], outpath: str = 'capiq ids.csv', folder: str = 'in_process_ids',
+                       config=None) -> List[str]:
     """
     Downloads Capital IQ identifiers when passed other identifiers such as CUSIP,
     ISIN, ticker, name, etc.
@@ -18,14 +19,22 @@ def download_capiq_ids(ids: Sequence[str], outpath: str = 'capiq ids.csv', folde
     :param ids: identifiers such as CUSIP, ISIN, ticker, name. Can be a mixture.
     :param folder: folder which will hold in process files
     :param outpath: filepath to output csv, including file extension
+    :param config: Optional CapiqConfig for dialect and add-in mode.
     :return: capiq ids
     """
+    # Resolve builder for formula generation
+    builder = None
+    if config is not None:
+        from capiq_excel.formulas import get_builder
+        dialect = config.resolve_dialect()
+        builder = get_builder(dialect)
+
     print('Creating XLSX files with commands to get ids')
     num_files = math.ceil(len(ids) / 100)
-    create_all_xlsx_with_id_commands(ids, folder, num_files=num_files)
+    create_all_xlsx_with_id_commands(ids, folder, num_files=num_files, builder=builder)
 
     print('Populating XLSX files for ids')
-    populate_all_ids_in_folder(folder)
+    populate_all_ids_in_folder(folder, config=config)
 
     print('Combining all ids into a single CSV file')
     combine_all_capiq_ids_xlsx(folder, outpath)
@@ -33,12 +42,21 @@ def download_capiq_ids(ids: Sequence[str], outpath: str = 'capiq ids.csv', folde
     return _get_ids_from_csv_path(outpath)
 
 
-def populate_all_ids_in_folder(folder, restart=True):
+def populate_all_ids_in_folder(folder, restart=True, config=None):
     excel = _start_excel_with_addins_and_attach()
+
+    # When config is available, detect runtime and load the right add-in
+    if config is not None:
+        from capiq_excel.addin import load_capiq_addin
+        try:
+            load_capiq_addin(excel, config)
+        except Exception as e:
+            print(f'Warning: Could not detect/load add-in ({e}), falling back to default behavior')
+
     file_tracker = FileProcessTracker(folder=folder, restart=restart, file_types=('xlsx',))
 
     for file in file_tracker.file_generator():
-        populate_capiq_ids_for_file(file, excel)
+        populate_capiq_ids_for_file(file, excel, config=config)
 
 
 def combine_all_capiq_ids_xlsx(infolder, outpath, restart=True):
@@ -58,7 +76,7 @@ def combine_all_capiq_ids_xlsx(infolder, outpath, restart=True):
 
 def _append_capiq_xlsx_to_df(df, filepath):
     temp_df = pd.read_excel(filepath)
-    df = df.append(temp_df)
+    df = pd.concat([df, temp_df], ignore_index=True)
 
     return df
 

--- a/capiq_excel/main.py
+++ b/capiq_excel/main.py
@@ -1,9 +1,44 @@
 from typing import List, Dict, Union, Sequence, Optional
+import copy
 import os
 from capiq_excel.workbook.create import create_all_xlsx_with_commands
 from capiq_excel.downloader.tools import populate_all_files_in_folder
 from capiq_excel.ids import download_capiq_ids, _get_ids_from_csv_path
 from capiq_excel.combine import combine_all_capiq_xlsx
+from capiq_excel.config import CapiqConfig, FormulaDialect
+from capiq_excel.formulas import get_builder
+
+
+def _resolve_config_dialect(config: CapiqConfig) -> CapiqConfig:
+    """Resolve AUTO dialect by starting Excel and detecting the runtime.
+
+    Returns a copy of the config with the dialect set to a concrete value
+    (CIQ or SPG), so all downstream code uses the same resolved dialect.
+    """
+    if config.formula_dialect != FormulaDialect.AUTO:
+        return config
+
+    ciq_compat = True  # safe default
+    try:
+        import time
+        from capiq_excel.runtime.addin_detection import detect_runtime
+        from exceldriver.tools import _start_excel_with_addins_and_attach
+        print('Detecting runtime environment...')
+        excel = _start_excel_with_addins_and_attach()
+        time.sleep(3)  # give add-ins time to load
+        profile = detect_runtime(excel)
+        ciq_compat = profile.ciq_compat_enabled if profile.ciq_compat_enabled is not None else True
+        print(f'  Pro installed: {profile.pro_installed}, CIQ compat: {ciq_compat}')
+        print(f'  Available dialects: {profile.available_dialects or "(none)"}')
+        print(f'  Add-in mode: {profile.addin_mode}')
+        excel.Quit()
+    except Exception as e:
+        print(f'  Runtime detection failed ({e}), defaulting to CIQ')
+
+    resolved = copy.copy(config)
+    resolved.formula_dialect = config.resolve_dialect(ciq_compat_available=ciq_compat)
+    print(f'Resolved formula dialect: {resolved.formula_dialect.value}')
+    return resolved
 
 
 def download_data(company_ids: List[str], financial_data_items: Optional[Union[Dict[str, str], Sequence[str]]] = None,
@@ -11,6 +46,7 @@ def download_data(company_ids: List[str], financial_data_items: Optional[Union[D
                   ids_folder: str = 'in_process_ids', data_folder: str = 'in_process_data',
                   data_outpath: str = 'capiq data.csv', ids_outpath: str = 'capiq ids.csv',
                   restart: bool = True, timeout: int = 240, run_failed: bool = False,
+                  config: Optional[CapiqConfig] = None,
                   **financial_command_kwargs):
     """
     Downloads data from Capital IQ given arbitrary ids such as name, ticker, CUSIP, ISIN, etc.
@@ -30,15 +66,21 @@ def download_data(company_ids: List[str], financial_data_items: Optional[Union[D
     :param timeout: Time to wait for file to be populated before considering it failed
     :param run_failed: Should only be set to True on a second or later run. Will target the failed files instead
         of the main files if True is passed.
+    :param config: Optional CapiqConfig for dialect selection, refresh mode, and retry settings.
+        If not provided, defaults to legacy CIQ behavior.
     :param financial_command_kwargs: kwargs for :py:func:`.financial_data_command`
     :return:
     """
+    # Early detection: resolve AUTO dialect once for the entire pipeline
+    if config is not None:
+        config = _resolve_config_dialect(config)
 
     if restart or not os.path.exists(ids_outpath):
         capiq_ids = download_capiq_ids(
             company_ids,
             outpath=ids_outpath,
-            folder=ids_folder
+            folder=ids_folder,
+            config=config,
         )
     else:
         capiq_ids = _get_ids_from_csv_path(ids_outpath)
@@ -52,6 +94,7 @@ def download_data(company_ids: List[str], financial_data_items: Optional[Union[D
         restart=restart,
         timeout=timeout,
         run_failed=run_failed,
+        config=config,
         **financial_command_kwargs
     )
 
@@ -62,6 +105,7 @@ def download_data_for_capiq_ids(capiq_company_ids: List[str],
                                 folder: str = 'in_process_data',
                                 outpath: str = 'capiq data.csv',
                                 restart: bool = True, timeout: int = 240, run_failed: bool = False,
+                                config: Optional[CapiqConfig] = None,
                                 **financial_command_kwargs):
     """
     Downloads data from Capital IQ given the capital IQ ids and chosen variables
@@ -79,10 +123,23 @@ def download_data_for_capiq_ids(capiq_company_ids: List[str],
     :param timeout: Time to wait for file to be populated before considering it failed
     :param run_failed: Should only be set to True on a second or later run. Will target the failed files instead
         of the main files if True is passed.
+    :param config: Optional CapiqConfig for dialect selection, refresh mode, and retry settings.
+        If not provided, defaults to legacy CIQ behavior.
     :param financial_command_kwargs: kwargs for :py:func:`.financial_data_command`
     :return:
     """
     financial_data_items, market_data_items = _get_data_items_dicts(financial_data_items, market_data_items)
+
+    # Resolve the formula dialect and create the builder.
+    # If called from download_data, dialect is already resolved (not AUTO).
+    # If called directly, do early detection if needed.
+    builder = None
+    if config is not None:
+        if config.formula_dialect == FormulaDialect.AUTO:
+            config = _resolve_config_dialect(config)
+        dialect = config.formula_dialect
+        print(f'Using formula dialect: {dialect.value}')
+        builder = get_builder(dialect)
 
     if restart or not os.path.exists(folder):
         print('Creating XLSX files with commands')
@@ -91,6 +148,7 @@ def download_data_for_capiq_ids(capiq_company_ids: List[str],
             company_id_list=capiq_company_ids,
             financial_data_items_dict=financial_data_items,
             market_data_items_dict=market_data_items,
+            builder=builder,
             **financial_command_kwargs
         )
 
@@ -102,6 +160,7 @@ def download_data_for_capiq_ids(capiq_company_ids: List[str],
         restart=restart,
         timeout=timeout,
         run_failed=run_failed,
+        config=config,
     )
 
     print('Combining individual XLSX files into a single CSV file')

--- a/capiq_excel/refresh/engine.py
+++ b/capiq_excel/refresh/engine.py
@@ -1,0 +1,241 @@
+"""
+Refresh engine for Capital IQ workbook evaluation.
+
+Replaces the legacy cell-A2 polling heuristic with strategy-based
+completion checks, configurable timeouts, and mode-aware refresh behavior.
+
+Supports two refresh strategies:
+  - Legacy CIQ: open workbook triggers auto-evaluation, poll cell A2
+  - Pro SPG/SNL: explicit VBA Application.Run commands via the Pro add-in
+
+VBA refresh commands (from CIQ Pro documentation):
+  - RefreshActiveCells: Application.Run "SNLxlAddin.xla!RefreshActiveCells"
+  - RefreshSheet:       Application.Run "SNLxlAddin.xla!RefreshSheet"
+  - RefreshWorkbook:    Application.Run "SNLxlAddin.xla!RefreshWorkbook"
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Optional
+
+from capiq_excel.config import AddinMode, CapiqConfig, RefreshScope
+from capiq_excel.exceptions import RefreshTimeoutError, CapitalIQInactiveException
+
+logger = logging.getLogger(__name__)
+
+# --- In-cell status tokens from the User Guide (p.62-63) ---
+
+# Tokens indicating the plugin is still evaluating (transient/retryable)
+PENDING_TOKENS = frozenset({
+    "#refresh",     # currently refreshing from servers
+    "#pend",        # needs refresh / export in progress
+    "fetching",
+    "loading",
+    "pending",
+    "calculating",
+})
+
+# Tokens indicating a hard error (not retryable without fixing the cause)
+HARD_ERROR_TOKENS = frozenset({
+    "#error",                       # general refresh problem
+    "#invalid company id",          # bad identifier
+    "#invalid metric name",         # bad field/metric
+    "#invalid function parameter",  # bad parameter
+    "#outside subscription",        # not subscribed
+    "keyerror",                     # missing secondary/tertiary key
+    "defunct",                      # deprecated field
+    "invalidcurrency",              # bad currency in options string
+    "invalidmagnitude",             # bad magnitude in options string
+    "invalidconvmethod",            # bad conversion method
+    "invalidparameter",             # generic invalid parameter
+    "#name",                        # add-in not loaded (Excel error)
+})
+
+# Tokens from legacy CIQ that indicate plugin-level failure
+LEGACY_ERROR_TOKENS = frozenset({
+    "ciqinactive",
+    "refresh",      # bare "refresh" in legacy mode = stuck
+})
+
+ALL_ERROR_TOKENS = HARD_ERROR_TOKENS | LEGACY_ERROR_TOKENS
+
+# Pro VBA macro names for Application.Run (via SNLxlAddin.xla)
+_VBA_REFRESH_SELECTED = "SNLxlAddin.xla!RefreshActiveCells"
+_VBA_REFRESH_SHEET = "SNLxlAddin.xla!RefreshSheet"
+_VBA_REFRESH_ALL = "SNLxlAddin.xla!RefreshWorkbook"
+
+# Default delay after workbook open to let the add-in initialize (seconds).
+# The Pro User Guide VBA example uses 10s; we default to 5 but make it configurable.
+DEFAULT_ADDIN_INIT_DELAY = 5.0
+
+
+def refresh_and_wait(
+    excel,
+    config: CapiqConfig,
+    *,
+    addin_mode: AddinMode = AddinMode.AUTO,
+    poll_interval: float = 1.0,
+    init_delay: float = DEFAULT_ADDIN_INIT_DELAY,
+) -> bool:
+    """
+    Trigger a refresh and wait for completion.
+
+    Args:
+        excel: COM Excel.Application instance.
+        config: Runtime configuration.
+        addin_mode: Which add-in is active (determines refresh strategy).
+        poll_interval: Seconds between readiness checks.
+        init_delay: Seconds to wait after triggering refresh before first poll
+                    (gives the add-in time to start evaluating).
+
+    Returns:
+        True if refresh completed successfully.
+
+    Raises:
+        RefreshTimeoutError: If timeout is exceeded.
+        CapitalIQInactiveException: If plugin reports an error state.
+    """
+    timeout = config.retry.timeout_seconds
+    scope = config.refresh_scope
+
+    logger.debug("Starting refresh (scope=%s, mode=%s, timeout=%ds)", scope.value, addin_mode.value, timeout)
+
+    # Trigger the appropriate refresh
+    _trigger_refresh(excel, scope, addin_mode)
+
+    # Wait for add-in to begin evaluation
+    if init_delay > 0:
+        time.sleep(init_delay)
+
+    # Poll for completion
+    start = time.monotonic()
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed > timeout:
+            raise RefreshTimeoutError(
+                f"Refresh did not complete within {timeout}s "
+                f"(scope={scope.value}, mode={addin_mode.value})"
+            )
+
+        status, detail = _check_readiness(excel)
+        if status == "ready":
+            logger.debug("Refresh completed in %.1fs", elapsed)
+            return True
+        elif status == "error":
+            raise CapitalIQInactiveException(
+                f"Capital IQ plugin reported an error during refresh: {detail}"
+            )
+        # status == "pending" -> keep waiting
+        time.sleep(poll_interval)
+
+
+def _trigger_refresh(excel, scope: RefreshScope, addin_mode: AddinMode) -> None:
+    """Trigger refresh using the appropriate mechanism.
+
+    Legacy CIQ: opening a workbook with CIQ formulas auto-triggers evaluation.
+    Pro SPG/SNL: we invoke VBA Application.Run macros for explicit refresh.
+    """
+    if addin_mode in (AddinMode.PRO, AddinMode.AUTO):
+        _trigger_pro_refresh(excel, scope)
+    # Legacy mode: formulas auto-evaluate on workbook open (no-op)
+
+
+def _trigger_pro_refresh(excel, scope: RefreshScope) -> None:
+    """Invoke the Pro add-in VBA refresh command."""
+    macro = {
+        RefreshScope.SELECTION: _VBA_REFRESH_SELECTED,
+        RefreshScope.WORKSHEET: _VBA_REFRESH_SHEET,
+        RefreshScope.WORKBOOK: _VBA_REFRESH_ALL,
+    }.get(scope, _VBA_REFRESH_SHEET)
+
+    try:
+        excel.Run(macro)
+        logger.debug("Triggered Pro refresh via %s", macro)
+    except Exception:
+        # If VBA macro fails (e.g. add-in not ready), log and fall through
+        # to polling — the formulas may still auto-evaluate
+        logger.warning("Failed to invoke Pro refresh macro %s, falling back to polling", macro, exc_info=True)
+
+
+def _check_readiness(excel) -> tuple[str, Optional[str]]:
+    """
+    Check whether the active sheet has finished evaluating.
+
+    Scans the first two rows across the first several columns for known
+    status/error tokens from CIQ and SPG/SNL. This covers both data worksheets
+    (formulas in column A) and ID lookup worksheets (formulas in columns B/D).
+
+    Also checks if formula cells have resolved — if a cell has a formula but
+    its value is 0/empty/None, the formula likely hasn't been evaluated yet.
+
+    Returns:
+        ("ready", None)          - data is present, no error/pending tokens
+        ("pending", token)       - still evaluating
+        ("error", error_detail)  - plugin reported an error
+    """
+    try:
+        ws = excel.ActiveSheet
+    except AttributeError:
+        return "error", "workbook_closed"
+
+    found_any_data = False
+    has_unresolved_formula = False
+
+    # Scan the first 2 rows x first 8 columns
+    for row in (1, 2):
+        for col in range(1, 9):
+            val = _get_cell_str(excel, col=col, row=row)
+
+            # Check if this cell has a formula that hasn't resolved
+            try:
+                cell = ws.Cells(row, col)
+                if cell.HasFormula:
+                    cell_val = cell.Value
+                    # COM error codes (e.g. -2146826259 = #NAME?) mean
+                    # the UDF hasn't registered yet — still pending
+                    if isinstance(cell_val, int) and cell_val < -2000000000:
+                        has_unresolved_formula = True
+                    # Formula cell with 0, empty, or None = likely unevaluated
+                    elif cell_val is None or cell_val == 0 or cell_val == "":
+                        has_unresolved_formula = True
+            except Exception:
+                pass
+
+            if val is None:
+                continue
+
+            val_lower = val.lower().strip()
+            if not val_lower:
+                continue
+
+            found_any_data = True
+
+            # Check for hard error states
+            for tok in ALL_ERROR_TOKENS:
+                if tok in val_lower:
+                    return "error", tok
+
+            # Check for pending states
+            for tok in PENDING_TOKENS:
+                if tok in val_lower:
+                    return "pending", tok
+
+    # If we found no data at all, still pending
+    if not found_any_data:
+        return "pending", "no_data"
+
+    # If any formula cell in row 2 hasn't resolved, still pending
+    if has_unresolved_formula:
+        return "pending", "unresolved_formula"
+
+    return "ready", None
+
+
+def _get_cell_str(excel, col: int, row: int) -> Optional[str]:
+    """Safely read a cell value as a string."""
+    try:
+        val = excel.ActiveSheet.Cells(row, col).Value
+        return str(val) if val is not None else None
+    except Exception:
+        return None

--- a/capiq_excel/runtime/addin_detection.py
+++ b/capiq_excel/runtime/addin_detection.py
@@ -1,0 +1,340 @@
+"""
+Add-in detection and runtime profiling for Capital IQ Excel plugins.
+
+Enumerates Excel COM add-ins and Windows registry keys to detect whether
+the legacy CIQ plugin, Capital IQ Pro, or both are installed and active.
+Returns a normalized RuntimeProfile used by the rest of the pipeline to
+select dialect and loading strategy.
+
+Registry keys (from Tech Guide p.6):
+  - Settings:      HKCU\\Software\\SNL Financial\\SNL Office
+  - Load behavior: HKCU\\Software\\Microsoft\\Office\\Excel\\Addins\\SNL.Clients.Office.Excel.ExcelAddIn
+  - OPEN keys:     HKCU\\Software\\Microsoft\\Office\\16.0\\Excel\\Options
+  - Install path:  %ProgramFiles%\\SNL Financial\\SNLxL  or  %ProgramFiles%\\SP Global Market Intelligence
+  - Logs:          %LocalAppData%\\SPGMI
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+from capiq_excel.config import AddinMode
+
+logger = logging.getLogger(__name__)
+
+# Known add-in identifiers (display names / ProgIDs)
+LEGACY_CIQ_NAMES = frozenset({
+    "S&P Capital IQ Excel Plug-in",
+    "Capital IQ Excel Plug-in",
+})
+PRO_ADDIN_NAMES = frozenset({
+    "S&P Capital IQ Pro",
+    "Capital IQ Pro",
+    "S&P Capital IQ Pro Office",
+    "S&P Cap IQ Pro Excel Add-In",
+})
+PRO_PROGIDS = frozenset({
+    "SNL.Clients.Office.Excel.ExcelAddIn",
+    "SPGMI.ExcelShell",
+})
+
+# Registry paths
+_REG_SNL_OFFICE = r"Software\SNL Financial\SNL Office"
+_REG_SNL_OFFICE_WOW64 = r"Software\Wow6432Node\SNL Financial\SNL Office"
+_REG_EXCEL_ADDINS = r"Software\Microsoft\Office\Excel\Addins\SNL.Clients.Office.Excel.ExcelAddIn"
+
+# Pro COM add-in ProgID (from OPEN1 registry key)
+PRO_PROGID = "SNL.Clients.Office.Excel.Functions"
+# Legacy CIQ UDF name (from OPEN2 registry key)
+CIQ_UDF_NAME = "ciqfunctions.udf"
+
+
+@dataclass
+class RuntimeProfile:
+    """Normalized snapshot of the detected Capital IQ environment."""
+    addin_mode: str = "unknown"  # "legacy" | "pro" | "mixed" | "unknown"
+    ciq_compat_enabled: Optional[bool] = None
+    available_dialects: set[str] = field(default_factory=set)
+    legacy_addin_name: Optional[str] = None
+    pro_addin_name: Optional[str] = None
+    excel_version: Optional[str] = None
+    excel_bitness: Optional[str] = None
+    # Registry-sourced info
+    pro_installed: bool = False
+    pro_load_behavior: Optional[int] = None  # 3 = load at startup
+    install_path: Optional[str] = None
+    log_path: Optional[str] = None
+
+
+def detect_runtime(excel) -> RuntimeProfile:
+    """
+    Inspect a running Excel COM instance and Windows registry,
+    then return a RuntimeProfile.
+
+    Args:
+        excel: A win32com Excel.Application object.
+
+    Returns:
+        RuntimeProfile describing the detected add-in environment.
+    """
+    profile = RuntimeProfile()
+
+    # Excel version info
+    try:
+        profile.excel_version = str(excel.Version)
+        profile.excel_bitness = _detect_bitness(excel)
+    except Exception:
+        logger.warning("Could not read Excel version info")
+
+    # Phase 1: Check Windows registry for installation state
+    _check_registry(profile)
+
+    # Phase 2: Scan COM add-ins on the running Excel instance
+    found_legacy = False
+    found_pro = False
+
+    try:
+        for addin in excel.COMAddIns:
+            name = addin.Description or ""
+            progid = getattr(addin, "ProgId", "") or ""
+            connected = addin.Connect
+
+            logger.debug("COM add-in: %s (ProgID=%s, connected=%s)", name, progid, connected)
+
+            if _matches_any(name, LEGACY_CIQ_NAMES):
+                found_legacy = True
+                profile.legacy_addin_name = name
+                if connected:
+                    profile.available_dialects.add("ciq")
+
+            if _matches_any(name, PRO_ADDIN_NAMES) or progid in PRO_PROGIDS or progid == PRO_PROGID:
+                found_pro = True
+                profile.pro_addin_name = name
+                if connected:
+                    profile.available_dialects.update({"spg", "snl"})
+    except Exception:
+        logger.warning("Could not enumerate COM add-ins", exc_info=True)
+
+    # Phase 3: Scan worksheet-function add-ins (AddIns collection)
+    try:
+        for addin in excel.AddIns:
+            name = getattr(addin, "Name", "") or ""
+            installed = getattr(addin, "Installed", False)
+
+            if _matches_any(name, LEGACY_CIQ_NAMES) and installed:
+                found_legacy = True
+                profile.legacy_addin_name = profile.legacy_addin_name or name
+                profile.available_dialects.add("ciq")
+
+            if _matches_any(name, PRO_ADDIN_NAMES) and installed:
+                found_pro = True
+                profile.pro_addin_name = profile.pro_addin_name or name
+                profile.available_dialects.update({"spg", "snl"})
+    except Exception:
+        logger.warning("Could not enumerate worksheet add-ins", exc_info=True)
+
+    # Phase 4: Determine CIQ compat from registry if Pro is present
+    if found_pro or profile.pro_installed:
+        found_pro = True
+        ciq_compat = _read_ciq_compat_from_registry()
+        if ciq_compat is not None:
+            profile.ciq_compat_enabled = ciq_compat
+            if ciq_compat:
+                profile.available_dialects.add("ciq")
+
+    # Phase 5: Determine overall mode
+    if found_legacy and found_pro:
+        profile.addin_mode = "mixed"
+        if profile.ciq_compat_enabled is None:
+            profile.ciq_compat_enabled = "ciq" in profile.available_dialects
+    elif found_pro:
+        profile.addin_mode = "pro"
+        if profile.ciq_compat_enabled is None:
+            profile.ciq_compat_enabled = "ciq" in profile.available_dialects
+    elif found_legacy:
+        profile.addin_mode = "legacy"
+        profile.ciq_compat_enabled = True
+    else:
+        profile.addin_mode = "unknown"
+
+    return profile
+
+
+def load_best_addin(excel, preferred_mode: AddinMode, profile: RuntimeProfile) -> str:
+    """
+    Load the most appropriate add-in based on preference and availability.
+
+    Returns the name of the add-in that was loaded/connected.
+    Raises AddinNotFoundError if no suitable add-in is found.
+    """
+    from capiq_excel.exceptions import AddinNotFoundError
+
+    # Build priority order based on preference
+    if preferred_mode == AddinMode.LEGACY:
+        candidates = [profile.legacy_addin_name]
+    elif preferred_mode == AddinMode.PRO:
+        candidates = [profile.pro_addin_name, profile.legacy_addin_name]
+    else:
+        # AUTO: prefer whatever is available, Pro first if both present
+        if profile.addin_mode == "mixed":
+            candidates = [profile.pro_addin_name, profile.legacy_addin_name]
+        elif profile.addin_mode == "pro":
+            candidates = [profile.pro_addin_name]
+        elif profile.addin_mode == "legacy":
+            candidates = [profile.legacy_addin_name]
+        else:
+            candidates = []
+
+    # Try each candidate
+    for name in candidates:
+        if name is None:
+            continue
+        try:
+            _connect_addin(excel, name)
+            logger.info("Loaded add-in: %s", name)
+            return name
+        except Exception:
+            logger.warning("Failed to load add-in: %s", name, exc_info=True)
+            continue
+
+    raise AddinNotFoundError(
+        f"No suitable Capital IQ add-in found. "
+        f"Mode={preferred_mode.value}, profile={profile.addin_mode}, "
+        f"legacy={profile.legacy_addin_name}, pro={profile.pro_addin_name}"
+    )
+
+
+def log_startup_diagnostics(profile: RuntimeProfile, config) -> None:
+    """Log a summary of the runtime environment at startup."""
+    logger.info("=== Capital IQ Runtime Diagnostics ===")
+    logger.info("Excel version: %s (%s)", profile.excel_version, profile.excel_bitness)
+    logger.info("Add-in mode: %s", profile.addin_mode)
+    logger.info("Legacy add-in: %s", profile.legacy_addin_name or "(not found)")
+    logger.info("Pro add-in: %s", profile.pro_addin_name or "(not found)")
+    logger.info("Pro installed (registry): %s", profile.pro_installed)
+    logger.info("Pro load behavior: %s", profile.pro_load_behavior)
+    logger.info("CIQ compat enabled: %s", profile.ciq_compat_enabled)
+    logger.info("Available dialects: %s", profile.available_dialects or "(none)")
+    logger.info("Install path: %s", profile.install_path or "(unknown)")
+    logger.info("Config dialect: %s", config.formula_dialect.value)
+    logger.info("Config addin_mode: %s", config.addin_mode.value)
+    logger.info("Config refresh_scope: %s", config.refresh_scope.value)
+    logger.info("======================================")
+
+
+# --- registry helpers ---
+
+def _check_registry(profile: RuntimeProfile) -> None:
+    """Read Windows registry to detect Pro installation state."""
+    try:
+        import winreg
+    except ImportError:
+        logger.debug("winreg not available (non-Windows platform)")
+        return
+
+    # Check Pro add-in load behavior
+    for reg_path in (_REG_EXCEL_ADDINS,):
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, reg_path) as key:
+                load_behavior, _ = winreg.QueryValueEx(key, "LoadBehavior")
+                profile.pro_installed = True
+                profile.pro_load_behavior = load_behavior
+                logger.debug("Pro LoadBehavior=%s from %s", load_behavior, reg_path)
+        except FileNotFoundError:
+            pass
+        except Exception:
+            logger.debug("Could not read registry key %s", reg_path, exc_info=True)
+
+    # Check SNL Office settings for install path and other info
+    for reg_path in (_REG_SNL_OFFICE, _REG_SNL_OFFICE_WOW64):
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, reg_path) as key:
+                profile.pro_installed = True
+                logger.debug("Found SNL Office registry key at %s", reg_path)
+                # Try to read proxy and other settings (informational)
+                try:
+                    proxy, _ = winreg.QueryValueEx(key, "ProxyServer")
+                    logger.debug("Proxy configured: %s", proxy)
+                except FileNotFoundError:
+                    pass
+        except FileNotFoundError:
+            pass
+        except Exception:
+            logger.debug("Could not read registry key %s", reg_path, exc_info=True)
+
+
+def _read_ciq_compat_from_registry() -> Optional[bool]:
+    """Check registry for the CIQ backward compatibility toggle.
+
+    The CIQ compat setting can be toggled in the Pro Settings UI (v21.08+)
+    and is stored under the SNL Office registry key.
+
+    Returns True/False if found, None if not detectable.
+    """
+    try:
+        import winreg
+    except ImportError:
+        return None
+
+    for reg_path in (_REG_SNL_OFFICE, _REG_SNL_OFFICE_WOW64):
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, reg_path) as key:
+                # The exact value name may vary; common patterns:
+                # Check for DisableCIQUDF first (inverted: 0 = enabled, 1 = disabled)
+                try:
+                    val, _ = winreg.QueryValueEx(key, "DisableCIQUDF")
+                    if isinstance(val, int):
+                        return val == 0  # 0 means NOT disabled = enabled
+                    if isinstance(val, str):
+                        return val.lower() in ("0", "false", "no")
+                except FileNotFoundError:
+                    pass
+
+                # Fall back to other possible key names
+                for value_name in ("CIQCompatibility", "EnableCIQFunctions", "CIQBackwardsCompatibility"):
+                    try:
+                        val, _ = winreg.QueryValueEx(key, value_name)
+                        # Interpret: 1/True/"Yes" = enabled
+                        if isinstance(val, int):
+                            return val != 0
+                        if isinstance(val, str):
+                            return val.lower() in ("1", "true", "yes")
+                    except FileNotFoundError:
+                        continue
+        except FileNotFoundError:
+            continue
+        except Exception:
+            logger.debug("Could not read CIQ compat from %s", reg_path, exc_info=True)
+
+    return None
+
+
+# --- COM helpers ---
+
+def _matches_any(name: str, known_names: frozenset[str]) -> bool:
+    """Case-insensitive substring match against known add-in names."""
+    lower = name.lower()
+    return any(known.lower() in lower for known in known_names)
+
+
+def _detect_bitness(excel) -> str:
+    """Attempt to determine Excel bitness (32/64-bit)."""
+    try:
+        if hasattr(excel, "Hinstance"):
+            import struct
+            return f"{struct.calcsize('P') * 8}-bit"
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _connect_addin(excel, name: str) -> None:
+    """Connect a COM add-in by display name."""
+    for addin in excel.COMAddIns:
+        desc = addin.Description or ""
+        if desc.lower() == name.lower():
+            if not addin.Connect:
+                addin.Connect = True
+            return
+    raise RuntimeError(f"Add-in '{name}' not found in COM add-ins collection")

--- a/capiq_excel/tools/dates.py
+++ b/capiq_excel/tools/dates.py
@@ -10,7 +10,11 @@ def freq_and_periods_to_begin_date_str(freq: str, periods: int) -> str:
 
 
 def _freq_and_periods_to_begin_date(freq: str, periods: int) -> pd.Timestamp:
-    all_dates = pd.date_range(end=datetime.datetime.today(), periods=periods, freq=freq)
+    # Map legacy CIQ frequency codes to pandas offset aliases.
+    # Pandas 3.x removed bare 'Q' and 'Y'; they are now 'QE' and 'YE'.
+    _FREQ_MAP = {"Q": "QE", "Y": "YE"}
+    pd_freq = _FREQ_MAP.get(freq, freq)
+    all_dates = pd.date_range(end=datetime.datetime.today(), periods=periods, freq=pd_freq)
     return all_dates[0]
 
 

--- a/capiq_excel/workbook/commands.py
+++ b/capiq_excel/workbook/commands.py
@@ -1,6 +1,88 @@
+"""
+Excel formula command generators.
+
+Legacy CIQ-only functions are preserved at the bottom for backward compatibility.
+New code should use the builder-aware factory functions (make_*_command).
+"""
+from __future__ import annotations
+
 from typing import Optional
+
+from capiq_excel.formulas.base import DialectBuilder, QuerySpec
 from capiq_excel.tools.dates import freq_and_periods_to_begin_date_str, today_as_str
 
+
+# ---------------------------------------------------------------------------
+# Builder-aware command factories
+#
+# Each factory returns a callable with the same signature as the legacy
+# function it replaces, so they can be used interchangeably by create.py.
+# ---------------------------------------------------------------------------
+
+def make_financial_command(builder: DialectBuilder):
+    """Return a financial-data command function bound to *builder*."""
+    def command(company_id: str, data_item: str, freq: str = 'Q', num_periods: int = 80,
+                data_item_label: Optional[str] = None) -> str:
+        spec = QuerySpec(
+            identifiers=[company_id],
+            metric=data_item,
+            metric_type="financial",
+            frequency=freq,
+            num_periods=num_periods,
+            label=data_item_label,
+        )
+        return builder.build_range(spec)
+    return command
+
+
+def make_market_command(builder: DialectBuilder):
+    """Return a market-data command function bound to *builder*."""
+    def command(company_id: str, data_item: str, freq: str = 'Q', num_periods: int = 80,
+                data_item_label: Optional[str] = None) -> str:
+        spec = QuerySpec(
+            identifiers=[company_id],
+            metric=data_item,
+            metric_type="market",
+            frequency=freq,
+            num_periods=num_periods,
+            label=data_item_label,
+        )
+        return builder.build_range(spec)
+    return command
+
+
+def make_holdings_command(builder: DialectBuilder):
+    """Return a holdings command function bound to *builder*."""
+    def command(company_id: str, data_item: str, date_str: str,
+                data_item_label: Optional[str] = None) -> str:
+        spec = QuerySpec(
+            identifiers=[company_id],
+            metric=data_item,
+            metric_type="ownership",
+            begin_date=date_str,
+            label=data_item_label,
+        )
+        return builder.build_range(spec)
+    return command
+
+
+def make_id_command(builder: DialectBuilder):
+    """Return an ID-lookup command function bound to *builder*."""
+    def command(search_str: str) -> str:
+        return builder.build_identifier_lookup(search_str, "IQ_COMPANY_ID_QUICK_MATCH")
+    return command
+
+
+def make_name_command(builder: DialectBuilder):
+    """Return a name-lookup command function bound to *builder*."""
+    def command(search_str: str) -> str:
+        return builder.build_identifier_lookup(search_str, "IQ_COMPANY_NAME_QUICK_MATCH")
+    return command
+
+
+# ---------------------------------------------------------------------------
+# Legacy CIQ-only functions (backward compatibility)
+# ---------------------------------------------------------------------------
 
 def financial_data_command(company_id: str, data_item: str, freq: str='Q', num_periods: int=80,
                            data_item_label: Optional[str]=None) -> str:

--- a/capiq_excel/workbook/create.py
+++ b/capiq_excel/workbook/create.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Dict, Iterable, Callable
+from typing import Sequence, Dict, Iterable, Callable, Optional
 import os
 import string
 import itertools
@@ -8,18 +8,26 @@ from openpyxl.utils.dataframe import dataframe_to_rows
 
 from exceldriver.workbook.create import get_workbook_and_worksheet
 from exceldriver.columns import excel_cols
-from .commands import financial_data_command, id_command, name_command, holdings_command, market_data_command
+from .commands import (
+    financial_data_command, id_command, name_command, holdings_command, market_data_command,
+    make_financial_command, make_market_command, make_holdings_command, make_id_command, make_name_command,
+)
+
+from capiq_excel.formulas.base import DialectBuilder
 
 
 def create_all_xlsx_with_commands(folder: str, company_id_list: Sequence[str],
                                   financial_data_items_dict: Dict[str, str],
-                                  market_data_items_dict: Dict[str, str], **financials_kwargs):
+                                  market_data_items_dict: Dict[str, str],
+                                  builder: Optional[DialectBuilder] = None,
+                                  **financials_kwargs):
     [
         create_xlsx_with_commands(
             folder,
             company_id,
             financial_data_items_dict,
             market_data_items_dict,
+            builder=builder,
             **financials_kwargs
         )
         for company_id in company_id_list
@@ -27,9 +35,12 @@ def create_all_xlsx_with_commands(folder: str, company_id_list: Sequence[str],
 
 
 def create_xlsx_with_commands(folder: str, company_id: str, financial_data_items_dict: Dict[str, str],
-                              market_data_items_dict: Dict[str, str], **financials_kwargs):
+                              market_data_items_dict: Dict[str, str],
+                              builder: Optional[DialectBuilder] = None,
+                              **financials_kwargs):
     wb, ws = get_workbook_and_worksheet()
-    _fill_with_commands(ws, company_id, financial_data_items_dict, market_data_items_dict, **financials_kwargs)
+    _fill_with_commands(ws, company_id, financial_data_items_dict, market_data_items_dict,
+                        builder=builder, **financials_kwargs)
 
     if not os.path.exists(folder):
         os.makedirs(folder)
@@ -39,23 +50,26 @@ def create_xlsx_with_commands(folder: str, company_id: str, financial_data_items
 
     return os.path.abspath(filepath)
 
-def create_all_xlsx_with_holdings_commands(folder, company_id_list, date_str_list, data_items_dict):
+def create_all_xlsx_with_holdings_commands(folder, company_id_list, date_str_list, data_items_dict,
+                                           builder: Optional[DialectBuilder] = None):
     [
-        create_xlsx_with_holdings_commands(folder, company_id, date_str, data_items_dict)
+        create_xlsx_with_holdings_commands(folder, company_id, date_str, data_items_dict, builder=builder)
         for company_id, date_str in itertools.product(company_id_list, date_str_list)
     ]
 
 
-def create_xlsx_with_holdings_commands(folder, company_id, date_str, data_items_dict):
+def create_xlsx_with_holdings_commands(folder, company_id, date_str, data_items_dict,
+                                       builder: Optional[DialectBuilder] = None):
     wb, ws = get_workbook_and_worksheet()
-    _fill_with_holdings_commands(ws, company_id, date_str, data_items_dict)
+    _fill_with_holdings_commands(ws, company_id, date_str, data_items_dict, builder=builder)
 
     filepath = os.path.join(folder, f'{company_id} {_date_str_to_file_format(date_str)}.xlsx')
     wb.save(filepath)
 
     return os.path.abspath(filepath)
 
-def create_all_xlsx_with_id_commands(ids: Sequence[str], folder, num_files=100):
+def create_all_xlsx_with_id_commands(ids: Sequence[str], folder, num_files=100,
+                                     builder: Optional[DialectBuilder] = None):
     wb, ws = get_workbook_and_worksheet()
 
     if not os.path.exists(folder):
@@ -63,8 +77,8 @@ def create_all_xlsx_with_id_commands(ids: Sequence[str], folder, num_files=100):
 
     df = pd.DataFrame()
     _fill_id_column(df, ids)
-    _fill_capiq_id_column(df)
-    _fill_capiq_name_column(df)
+    _fill_capiq_id_column(df, builder=builder)
+    _fill_capiq_name_column(df, builder=builder)
 
     rows_per_ws = math.ceil(len(df)/num_files) + 1  # one additional row for headers
 
@@ -96,30 +110,49 @@ def _fill_id_column(df: pd.DataFrame, ids: Sequence[str]):
     """
     df['ID'] = ids
 
-def _fill_capiq_id_column(df):
+def _fill_capiq_id_column(df, builder: Optional[DialectBuilder] = None):
     """
     NOTE: inplace
     """
-    df['Blank 1'] = df['ID'].apply(id_command)
+    id_cmd = make_id_command(builder) if builder is not None else id_command
 
-    # Blank needed because ids will populate to the right by one column
-    df['IQID'] = ''
+    if builder is not None:
+        # Builder-based: CIQ() returns value in-cell (no right-expansion)
+        df['IQID'] = df['ID'].apply(id_cmd)
+    else:
+        # Legacy: CIQRANGEA expands one column to the right
+        df['Blank 1'] = df['ID'].apply(id_cmd)
+        df['IQID'] = ''
 
 
-def _fill_capiq_name_column(df):
+def _fill_capiq_name_column(df, builder: Optional[DialectBuilder] = None):
     """
     NOTE: inplace
     """
-    df['Blank 2'] = df['ID'].apply(name_command)
+    name_cmd = make_name_command(builder) if builder is not None else name_command
 
-    # Blank needed because ids will populate to the right by one column
-    df['IQ Name'] = ''
+    if builder is not None:
+        # Builder-based: CIQ() returns value in-cell (no right-expansion)
+        df['IQ Name'] = df['ID'].apply(name_cmd)
+    else:
+        # Legacy: CIQRANGEA expands one column to the right
+        df['Blank 2'] = df['ID'].apply(name_cmd)
+        df['IQ Name'] = ''
 
 def _fill_with_commands(ws, company_id: str, financial_data_items_dict: Dict[str, str],
-                        market_data_items_dict: Dict[str, str], **financials_kwargs):
+                        market_data_items_dict: Dict[str, str],
+                        builder: Optional[DialectBuilder] = None,
+                        **financials_kwargs):
     """
     Note: inplace
     """
+    # Resolve command functions: builder-aware when available, legacy otherwise
+    if builder is not None:
+        fin_cmd = make_financial_command(builder)
+        mkt_cmd = make_market_command(builder)
+    else:
+        fin_cmd = financial_data_command
+        mkt_cmd = market_data_command
 
     # Set default freq
     try:
@@ -137,9 +170,9 @@ def _fill_with_commands(ws, company_id: str, financial_data_items_dict: Dict[str
         company_id
     )
 
-    _fill_ws_by_data_item_dict(date_dict, financial_data_command, *common_args, **financials_kwargs)
-    _fill_ws_by_data_item_dict(financial_data_items_dict, financial_data_command, *common_args, **financials_kwargs)
-    _fill_ws_by_data_item_dict(market_data_items_dict, market_data_command, *common_args, **financials_kwargs)
+    _fill_ws_by_data_item_dict(date_dict, fin_cmd, *common_args, **financials_kwargs)
+    _fill_ws_by_data_item_dict(financial_data_items_dict, fin_cmd, *common_args, **financials_kwargs)
+    _fill_ws_by_data_item_dict(market_data_items_dict, mkt_cmd, *common_args, **financials_kwargs)
 
 
 
@@ -156,12 +189,14 @@ def _fill_ws_by_data_item_dict(data_items_dict: Dict[str, str], command_func: Ca
         )
 
 
-def _fill_with_holdings_commands(ws, company_id, date_str, data_items_dict):
+def _fill_with_holdings_commands(ws, company_id, date_str, data_items_dict,
+                                  builder: Optional[DialectBuilder] = None):
+    hold_cmd = make_holdings_command(builder) if builder is not None else holdings_command
     column_generator = excel_cols()
 
     for item in data_items_dict:
         current_column = next(column_generator)
-        ws[f'{current_column}1'] = holdings_command(
+        ws[f'{current_column}1'] = hold_cmd(
             company_id, item, date_str,
             data_item_label=data_items_dict[item]
         )
@@ -185,5 +220,3 @@ def _get_date_var_dict_from_freq(freq) -> Dict[str, str]:
 
 def _date_str_to_file_format(date_str):
     return date_str.replace('/','-')
-
-

--- a/capiq_excel/workbook/populate/main.py
+++ b/capiq_excel/workbook/populate/main.py
@@ -1,7 +1,7 @@
 import sys
 import time
 import traceback
-from typing import Dict
+from typing import Dict, Optional
 
 import pythoncom
 from win32com.client import constants
@@ -15,19 +15,42 @@ from capiq_excel.workbook.populate.extract import extract_capiq_df_from_sheet
 from capiq_excel.workbook.populate.replace import write_df_to_ws_values
 
 
+def _wait_for_data(excel, config=None):
+    """Wait for plugin to finish evaluating formulas.
+
+    Uses the new refresh engine when *config* is provided (Pro-aware with
+    expanded token detection).  Falls back to legacy cell-A2 polling otherwise.
+    """
+    if config is not None:
+        from capiq_excel.config import AddinMode
+        from capiq_excel.refresh.engine import refresh_and_wait
+        # For AUTO mode, try Pro refresh (it handles both Pro and CIQ-compat).
+        # Only use LEGACY when explicitly configured.
+        if config.addin_mode == AddinMode.LEGACY:
+            addin_mode = AddinMode.LEGACY
+        else:
+            addin_mode = AddinMode.PRO
+        refresh_and_wait(excel, config, addin_mode=addin_mode)
+    else:
+        _wait_for_capiq_result(excel)
+
 
 def populate_capiq_for_file(filepath, excel, financial_data_items_dict: Dict[str, str],
-                            market_data_items_dict: Dict[str, str], retries_remaining=3, close_workbook=False, index=0):
+                            market_data_items_dict: Dict[str, str], retries_remaining=3,
+                            close_workbook=False, index=0, config=None):
     """
-
     Private function has main functionality. This is a wrapper to add retries afer com errors
     """
 
     # Necessary to be called in each new thread or process which uses COM (communicate with Microsoft products)
     pythoncom.CoInitialize()
 
-    # Even if things are going normally, restart every 500 worksheets as there is a memory leak
-    if index % 500 == 0 and retries_remaining == 3:
+    restart_interval = 500
+    if config is not None:
+        restart_interval = config.retry.restart_interval
+
+    # Even if things are going normally, restart every N worksheets as there is a memory leak
+    if index % restart_interval == 0 and retries_remaining == 3:
         excel = _restart_excel_with_addins_and_attach()
 
     # Stop retries
@@ -44,12 +67,16 @@ def populate_capiq_for_file(filepath, excel, financial_data_items_dict: Dict[str
                 excel.ActiveWorkbook.Close(SaveChanges=False)
             time.sleep(5)
 
-        _populate_capiq_for_file(filepath, excel, financial_data_items_dict, market_data_items_dict)
+        _populate_capiq_for_file(filepath, excel, financial_data_items_dict, market_data_items_dict,
+                                 config=config)
         return excel, True
     except (com_error, WorkbookClosedException, CapitalIQInactiveException) as e:
         print(f'Error {e} populating {filepath}. Will wait 30 seconds, restart Excel, and try again.')
         traceback.print_tb(sys.exc_info()[2])
-        time.sleep(30)
+        retry_delay = 30
+        if config is not None:
+            retry_delay = config.retry.retry_delay_seconds
+        time.sleep(retry_delay)
         excel = _restart_excel_with_addins_and_attach()
         return populate_capiq_for_file(
             filepath,
@@ -57,26 +84,27 @@ def populate_capiq_for_file(filepath, excel, financial_data_items_dict: Dict[str
             financial_data_items_dict,
             market_data_items_dict,
             retries_remaining=retries_remaining - 1,
-            close_workbook=True
+            close_workbook=True,
+            config=config,
         )
 
 
 def _populate_capiq_for_file(filepath, excel, financial_data_items_dict: Dict[str, str],
-                            market_data_items_dict: Dict[str, str]):
+                            market_data_items_dict: Dict[str, str], config=None):
     wb = excel.Workbooks.Open(filepath)
-    successful = _wait_for_capiq_result(excel)
+    _wait_for_data(excel, config=config)
     _set_date_format(excel, wb, cell_range='A:A')  # column A is automatically included date
     _extract_unaligned_data_align_and_replace(wb, market_data_items_dict)
     excel.ActiveWorkbook.Close(SaveChanges=True)
-    return successful
+    return True
 
 
-def populate_capiq_ids_for_file(filepath, excel):
+def populate_capiq_ids_for_file(filepath, excel, config=None):
     wb = excel.Workbooks.Open(filepath)
-    successful = _wait_for_capiq_result(excel)
+    _wait_for_data(excel, config=config)
     _copy_paste_values(excel, wb, cell_range='A:Z')
     excel.ActiveWorkbook.Close(SaveChanges=True)
-    return successful
+    return True
 
 
 def _copy_paste_values(excel, wb, cell_range='A1:ZZ20000'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "capiq-excel"
+version = "0.5.0-beta.1"
+description = "Capital IQ Data Downloader using Python to drive Excel Plugin (Legacy + Pro)"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+authors = [
+    { name = "Nick DeRobertis", email = "whoopnip@gmail.com" },
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Financial and Insurance Industry",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: Microsoft :: Windows",
+    "Topic :: Office/Business :: Financial",
+]
+dependencies = [
+    "exceldriver",
+    "processfiles",
+    "pypiwin32",
+    "openpyxl",
+    "pandas>=1.5",
+    "xlrd",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov",
+]
+
+[project.urls]
+Code = "https://github.com/nickderobertis/capiq-excel-downloader-py/"
+Documentation = "https://nickderobertis.github.io/capiq-excel-downloader-py/"
+
+[project.scripts]
+capiq = "capiq_excel.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["capiq_excel*"]
+
+[tool.pytest.ini_options]
+testpaths = ["test"]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,93 @@
+"""Tests for config module."""
+import os
+import pytest
+from capiq_excel.config import (
+    CapiqConfig, FormulaDialect, AddinMode, RefreshScope, FormulaOptions
+)
+
+
+class TestCapiqConfigDefaults:
+    def test_defaults_are_legacy_compatible(self):
+        cfg = CapiqConfig()
+        assert cfg.formula_dialect == FormulaDialect.AUTO
+        assert cfg.addin_mode == AddinMode.AUTO
+        assert cfg.refresh_scope == RefreshScope.WORKSHEET
+        assert cfg.freq == "Q"
+        assert cfg.num_periods == 80
+
+    def test_retry_defaults(self):
+        cfg = CapiqConfig()
+        assert cfg.retry.max_retries == 3
+        assert cfg.retry.timeout_seconds == 240
+        assert cfg.retry.restart_interval == 500
+
+
+class TestCapiqConfigFromEnv:
+    def test_reads_dialect_from_env(self, monkeypatch):
+        monkeypatch.setenv("CAPIQ_FORMULA_DIALECT", "spg")
+        cfg = CapiqConfig.from_env()
+        assert cfg.formula_dialect == FormulaDialect.SPG
+
+    def test_reads_mode_from_env(self, monkeypatch):
+        monkeypatch.setenv("CAPIQ_ADDIN_MODE", "legacy")
+        cfg = CapiqConfig.from_env()
+        assert cfg.addin_mode == AddinMode.LEGACY
+
+    def test_defaults_when_env_not_set(self):
+        for key in ("CAPIQ_FORMULA_DIALECT", "CAPIQ_ADDIN_MODE", "CAPIQ_REFRESH_SCOPE"):
+            os.environ.pop(key, None)
+        cfg = CapiqConfig.from_env()
+        assert cfg.formula_dialect == FormulaDialect.AUTO
+        assert cfg.addin_mode == AddinMode.AUTO
+
+
+class TestResolveDialect:
+    def test_auto_with_ciq_compat(self):
+        cfg = CapiqConfig(formula_dialect=FormulaDialect.AUTO)
+        assert cfg.resolve_dialect(ciq_compat_available=True) == FormulaDialect.CIQ
+
+    def test_auto_without_ciq_compat(self):
+        cfg = CapiqConfig(formula_dialect=FormulaDialect.AUTO)
+        assert cfg.resolve_dialect(ciq_compat_available=False) == FormulaDialect.SPG
+
+    def test_explicit_dialect_ignores_compat(self):
+        cfg = CapiqConfig(formula_dialect=FormulaDialect.SPG)
+        assert cfg.resolve_dialect(ciq_compat_available=True) == FormulaDialect.SPG
+
+
+class TestFormulaOptions:
+    def test_empty_options_returns_none(self):
+        opts = FormulaOptions()
+        assert opts.to_spg_options_string() is None
+
+    def test_single_option(self):
+        opts = FormulaOptions(currency="USD")
+        assert opts.to_spg_options_string() == "Curr=USD"
+
+    def test_multiple_options(self):
+        opts = FormulaOptions(currency="EUR", magnitude="Millions", conversion_method="Recommended")
+        result = opts.to_spg_options_string()
+        assert result == "Curr=EUR,Mag=Millions,ConvMethod=Recommended"
+
+    def test_all_options(self):
+        opts = FormulaOptions(
+            currency="GBP",
+            magnitude="Billions",
+            conversion_method="MRSpot",
+            null_display="NA",
+            terminology="en-GB",
+        )
+        result = opts.to_spg_options_string()
+        assert "Curr=GBP" in result
+        assert "Mag=Billions" in result
+        assert "ConvMethod=MRSpot" in result
+        assert "NullValue=NA" in result
+        assert "Terminology=en-GB" in result
+
+    def test_reported_currency(self):
+        opts = FormulaOptions(currency="RC")
+        assert opts.to_spg_options_string() == "Curr=RC"
+
+    def test_terminology_only(self):
+        opts = FormulaOptions(terminology="ja-JP")
+        assert opts.to_spg_options_string() == "Terminology=ja-JP"

--- a/test/test_formulas.py
+++ b/test/test_formulas.py
@@ -1,0 +1,366 @@
+"""Snapshot tests for formula generation across all dialects."""
+import pytest
+from capiq_excel.config import FormulaOptions
+from capiq_excel.formulas.base import QuerySpec
+from capiq_excel.formulas.ciq_builder import CiqBuilder
+from capiq_excel.formulas.spg_builder import SpgBuilder
+from capiq_excel.formulas.snl_builder import SnlBuilder
+
+
+@pytest.fixture
+def ciq():
+    return CiqBuilder()
+
+
+@pytest.fixture
+def spg():
+    return SpgBuilder()
+
+
+@pytest.fixture
+def snl():
+    return SnlBuilder()
+
+
+# ============================================================
+# CIQ Builder
+# ============================================================
+
+class TestCiqBuilderFinancial:
+    def test_financial_range_quarterly(self, ciq):
+        spec = QuerySpec(
+            identifiers=["IQ21835"],
+            metric="IQ_TOTAL_REV",
+            metric_type="financial",
+            frequency="Q",
+            num_periods=80,
+            label="Sales",
+        )
+        result = ciq.build_range(spec)
+        assert result == '=CIQRANGE("IQ21835", "IQ_TOTAL_REV", IQ_FQ - 80, , , , , , "Sales")'
+
+    def test_financial_range_yearly(self, ciq):
+        spec = QuerySpec(
+            identifiers=["IQ21835"],
+            metric="IQ_TOTAL_REV",
+            metric_type="financial",
+            frequency="Y",
+            num_periods=20,
+        )
+        result = ciq.build_range(spec)
+        assert result == '=CIQRANGE("IQ21835", "IQ_TOTAL_REV", IQ_FY - 20, , , , , , "IQ_TOTAL_REV")'
+
+    def test_financial_range_default_label(self, ciq):
+        spec = QuerySpec(
+            identifiers=["IQ21835"],
+            metric="IQ_COST_REV",
+            metric_type="financial",
+        )
+        result = ciq.build_range(spec)
+        assert '"IQ_COST_REV")' in result
+
+
+class TestCiqBuilderMarket:
+    def test_market_range_with_dates(self, ciq):
+        spec = QuerySpec(
+            identifiers=["IQ21835"],
+            metric="IQ_FLOAT_PERCENT",
+            metric_type="market",
+            begin_date="01/01/2020",
+            end_date="12/31/2024",
+            label="Float %",
+        )
+        result = ciq.build_range(spec)
+        assert result == '=CIQRANGE("IQ21835", "IQ_FLOAT_PERCENT", "01/01/2020", "12/31/2024", , , , , "Float %")'
+
+
+class TestCiqBuilderIdLookup:
+    def test_id_lookup(self, ciq):
+        result = ciq.build_identifier_lookup("MSFT")
+        assert result == '=CIQ("MSFT","IQ_COMPANY_ID")'
+
+    def test_name_lookup(self, ciq):
+        result = ciq.build_identifier_lookup("AAPL", "IQ_COMPANY_NAME_QUICK_MATCH")
+        assert result == '=CIQ("AAPL","IQ_COMPANY_NAME")'
+
+
+class TestCiqBuilderTable:
+    def test_table_falls_back_to_range(self, ciq):
+        spec = QuerySpec(
+            identifiers=["IQ21835"],
+            metric="IQ_TOTAL_REV",
+            metric_type="financial",
+            frequency="Q",
+            num_periods=80,
+            label="Sales",
+        )
+        assert ciq.build_table(spec) == ciq.build_range(spec)
+
+
+# ============================================================
+# SPG Builder
+# ============================================================
+
+class TestSpgBuilderSingleValue:
+    def test_basic_single_value(self, spg):
+        spec = QuerySpec(identifiers=["IQ21835"], metric="IQ_TOTAL_REV")
+        result = spg.build_single_value(spec)
+        assert result == '=SPG("IQ21835", "IQ_TOTAL_REV", "FQ0")'
+
+    def test_single_value_with_period(self, spg):
+        spec = QuerySpec(identifiers=["SPGI"], metric="SP_TOTAL_REV", period="FY2020")
+        result = spg.build_single_value(spec)
+        assert result == '=SPG("SPGI", "SP_TOTAL_REV", "FY2020")'
+
+    def test_single_value_with_options(self, spg):
+        spec = QuerySpec(
+            identifiers=["SPGI"],
+            metric="SP_TOTAL_REV",
+            period="FY0",
+            options=FormulaOptions(currency="USD", magnitude="Millions"),
+        )
+        result = spg.build_single_value(spec)
+        assert "Curr=USD,Mag=Millions" in result
+        assert result.startswith("=SPG(")
+
+
+class TestSpgBuilderRange:
+    def test_financial_range_uses_period_codes(self, spg):
+        spec = QuerySpec(
+            identifiers=["IQ21835"],
+            metric="IQ_TOTAL_REV",
+            metric_type="financial",
+            frequency="Q",
+            num_periods=80,
+        )
+        result = spg.build_range(spec)
+        # Should use FQ-80 and FQ0, NOT date strings
+        assert "FQ-80" in result
+        assert "FQ0" in result
+        assert result.startswith("=SPGRangeV(")
+
+    def test_financial_range_yearly(self, spg):
+        spec = QuerySpec(
+            identifiers=["IQ21835"],
+            metric="IQ_TOTAL_REV",
+            metric_type="financial",
+            frequency="Y",
+            num_periods=20,
+        )
+        result = spg.build_range(spec)
+        assert "FY-20" in result
+        assert "FY0" in result
+
+    def test_range_with_explicit_periods(self, spg):
+        spec = QuerySpec(
+            identifiers=["SPGI"],
+            metric="SP_TOTAL_REV",
+            begin_date="FQ12017",
+            end_date="FQ42020",
+        )
+        result = spg.build_range(spec)
+        assert '"FQ12017"' in result
+        assert '"FQ42020"' in result
+
+    def test_range_with_options(self, spg):
+        spec = QuerySpec(
+            identifiers=["SPGI"],
+            metric="SP_TOTAL_REV",
+            frequency="Y",
+            num_periods=5,
+            options=FormulaOptions(currency="EUR", magnitude="Billions"),
+        )
+        result = spg.build_range(spec)
+        assert "Curr=EUR,Mag=Billions" in result
+
+
+class TestSpgBuilderTable:
+    def test_table_formula(self, spg):
+        spec = QuerySpec(
+            identifiers=["IQ21835"],
+            metric="IQ_TOTAL_REV",
+            period="FQ0",
+        )
+        result = spg.build_table(spec)
+        assert result.startswith("=SPGTable(")
+        assert '"IQ21835"' in result
+        assert '"FQ0"' in result
+
+    def test_table_with_options(self, spg):
+        spec = QuerySpec(
+            identifiers=["SPGI"],
+            metric="SP_TOTAL_REV",
+            period="FY2020",
+            options=FormulaOptions(currency="USD"),
+        )
+        result = spg.build_table(spec)
+        assert "Curr=USD" in result
+
+
+class TestSpgBuilderIdLookup:
+    def test_id_lookup(self, spg):
+        result = spg.build_identifier_lookup("MSFT")
+        assert result == '=SPG("MSFT", "IQ_COMPANY_ID_QUICK_MATCH")'
+
+
+# ============================================================
+# SNL Builder
+# ============================================================
+
+class TestSnlBuilderSingleValue:
+    def test_basic_snldata(self, snl):
+        spec = QuerySpec(
+            identifiers=["4023623"],
+            metric="SNL_TOTAL_ASSETS",
+            dataset=1,
+            secondary_key="2020Q4",
+        )
+        result = snl.build_single_value(spec)
+        assert result == '=SNLData(1, "4023623", "SNL_TOTAL_ASSETS", "2020Q4")'
+
+    def test_snldata_with_tertiary(self, snl):
+        spec = QuerySpec(
+            identifiers=["4023623"],
+            metric="SNL_TOTAL_ASSETS",
+            dataset=1,
+            secondary_key="2020Q4",
+            tertiary_key="Originally Reported",
+        )
+        result = snl.build_single_value(spec)
+        assert '"Originally Reported"' in result
+
+    def test_snldata_with_options(self, snl):
+        spec = QuerySpec(
+            identifiers=["4023623"],
+            metric="SNL_TOTAL_ASSETS",
+            dataset=1,
+            secondary_key="MRY",
+            options=FormulaOptions(currency="USD", magnitude="Millions"),
+        )
+        result = snl.build_single_value(spec)
+        assert "Curr=USD,Mag=Millions" in result
+
+    def test_snldata_default_dataset(self, snl):
+        spec = QuerySpec(identifiers=["4023623"], metric="SNL_TOTAL_ASSETS")
+        result = snl.build_single_value(spec)
+        assert result.startswith("=SNLData(1,")
+
+
+class TestSnlBuilderRange:
+    def test_market_data_range(self, snl):
+        spec = QuerySpec(
+            identifiers=["SPGI"],
+            metric="SNL_CLOSE_PRICE",
+            metric_type="market",
+            begin_date="01/01/2020",
+            end_date="12/31/2024",
+        )
+        result = snl.build_range(spec)
+        assert result.startswith("=SNLMarkets(")
+        assert '"01/01/2020"' in result
+        assert '"12/31/2024"' in result
+
+    def test_non_market_falls_back_to_snldata(self, snl):
+        spec = QuerySpec(
+            identifiers=["4023623"],
+            metric="SNL_TOTAL_ASSETS",
+            metric_type="financial",
+            dataset=1,
+            secondary_key="MRY",
+        )
+        result = snl.build_range(spec)
+        assert result.startswith("=SNLData(")
+
+
+class TestSnlBuilderTable:
+    def test_snltable(self, snl):
+        spec = QuerySpec(
+            identifiers=["4023623"],
+            metric="SNL_TOTAL_ASSETS",
+            dataset=1,
+            secondary_key="MRY",
+        )
+        result = snl.build_table(spec)
+        assert result.startswith("=SNLTable(1,")
+        assert '"MRY"' in result
+
+    def test_snltable_with_options(self, snl):
+        spec = QuerySpec(
+            identifiers=["4023623"],
+            metric="SNL_TOTAL_ASSETS",
+            dataset=266637,
+            secondary_key="MRQ",
+            options=FormulaOptions(currency="GBP"),
+        )
+        result = snl.build_table(spec)
+        assert "=SNLTable(266637," in result
+        assert "Curr=GBP" in result
+
+
+class TestSnlBuilderIdLookup:
+    def test_id_lookup(self, snl):
+        result = snl.build_identifier_lookup("MSFT")
+        assert result == '=SNLData(1, "MSFT", "IQ_COMPANY_ID_QUICK_MATCH")'
+
+
+class TestSnlBuilderSpecialFunctions:
+    def test_query(self, snl):
+        result = snl.build_query("My Saved Screen")
+        assert result == '=SNLQuery("My Saved Screen")'
+
+    def test_query_with_fields(self, snl):
+        result = snl.build_query("My Screen", field_range="A1:A5")
+        assert result == '=SNLQuery("My Screen", A1:A5)'
+
+    def test_definition(self, snl):
+        result = snl.build_definition(1, "SNL_TOTAL_ASSETS")
+        assert result == '=SNLDefinition(1, "SNL_TOTAL_ASSETS")'
+
+    def test_definition_with_terminology(self, snl):
+        result = snl.build_definition(1, "SNL_TOTAL_ASSETS", terminology="ja-JP")
+        assert result == '=SNLDefinition(1, "SNL_TOTAL_ASSETS", "ja-JP")'
+
+    def test_convert(self, snl):
+        result = snl.build_convert(1, "A1:A10", 17)
+        assert result == "=SNLConvert(1, A1:A10, 17)"
+
+
+# ============================================================
+# Cross-Dialect Parity
+# ============================================================
+
+class TestDialectParity:
+    """Ensure all builders accept the same QuerySpec inputs."""
+
+    def test_same_spec_all_three_dialects(self, ciq, spg, snl):
+        spec = QuerySpec(
+            identifiers=["IQ21835"],
+            metric="IQ_TOTAL_REV",
+            metric_type="financial",
+            frequency="Q",
+            num_periods=10,
+            label="Revenue",
+        )
+        ciq_result = ciq.build_range(spec)
+        spg_result = spg.build_range(spec)
+        snl_result = snl.build_range(spec)  # non-market falls back to SNLData
+
+        # Each dialect produces a valid formula starting with its prefix
+        assert ciq_result.startswith("=CIQ")
+        assert spg_result.startswith("=SPG")
+        assert snl_result.startswith("=SNL")
+
+    def test_all_builders_have_table_method(self, ciq, spg, snl):
+        spec = QuerySpec(
+            identifiers=["IQ21835"],
+            metric="IQ_TOTAL_REV",
+        )
+        # All should return strings without error
+        assert isinstance(ciq.build_table(spec), str)
+        assert isinstance(spg.build_table(spec), str)
+        assert isinstance(snl.build_table(spec), str)
+
+    def test_dialect_names(self, ciq, spg, snl):
+        assert ciq.dialect_name() == "ciq"
+        assert spg.dialect_name() == "spg"
+        assert snl.dialect_name() == "snl"

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -1,0 +1,218 @@
+"""
+Smoke tests for the modernized capiq-excel pipeline.
+
+Tests the full integration path without requiring COM/Excel.
+Validates that config -> dialect resolution -> builder -> command factories
+all wire together correctly.
+"""
+import pytest
+from capiq_excel.config import CapiqConfig, FormulaDialect, AddinMode, FormulaOptions
+from capiq_excel.formulas import get_builder
+from capiq_excel.formulas.base import QuerySpec
+from capiq_excel.formulas.ciq_builder import CiqBuilder
+from capiq_excel.formulas.spg_builder import SpgBuilder
+from capiq_excel.workbook.commands import (
+    make_financial_command,
+    make_market_command,
+    make_holdings_command,
+    make_id_command,
+    make_name_command,
+    financial_data_command,
+    market_data_command,
+    id_command,
+    name_command,
+)
+
+
+# ============================================================
+# get_builder factory
+# ============================================================
+
+class TestGetBuilder:
+    def test_ciq_dialect_returns_ciq_builder(self):
+        builder = get_builder(FormulaDialect.CIQ)
+        assert isinstance(builder, CiqBuilder)
+        assert builder.dialect_name() == "ciq"
+
+    def test_spg_dialect_returns_spg_builder(self):
+        builder = get_builder(FormulaDialect.SPG)
+        assert isinstance(builder, SpgBuilder)
+        assert builder.dialect_name() == "spg"
+
+    def test_auto_dialect_raises(self):
+        with pytest.raises(ValueError, match="resolved"):
+            get_builder(FormulaDialect.AUTO)
+
+
+# ============================================================
+# Builder-aware command factories
+# ============================================================
+
+class TestMakeFinancialCommand:
+    def test_ciq_builder_matches_legacy(self):
+        builder = get_builder(FormulaDialect.CIQ)
+        cmd = make_financial_command(builder)
+        result = cmd("IQ21835", "IQ_TOTAL_REV", freq="Q", num_periods=80, data_item_label="Sales")
+        # Should produce a CIQRANGE formula
+        assert result.startswith("=CIQRANGE(")
+        assert '"IQ21835"' in result
+        assert '"IQ_TOTAL_REV"' in result
+        assert '"Sales"' in result
+
+    def test_spg_builder_produces_spg_range(self):
+        builder = get_builder(FormulaDialect.SPG)
+        cmd = make_financial_command(builder)
+        result = cmd("IQ21835", "IQ_TOTAL_REV", freq="Q", num_periods=80)
+        assert result.startswith("=SPGRangeV(")
+        assert "FQ-80" in result
+        assert "FQ0" in result
+
+
+class TestMakeMarketCommand:
+    def test_ciq_builder_market(self):
+        builder = get_builder(FormulaDialect.CIQ)
+        cmd = make_market_command(builder)
+        result = cmd("IQ21835", "IQ_CLOSEPRICE", freq="Q", num_periods=20)
+        assert result.startswith("=CIQRANGE(")
+        # Market data should have date strings in CIQ mode
+        assert "IQ_CLOSEPRICE" in result
+
+    def test_spg_builder_market(self):
+        builder = get_builder(FormulaDialect.SPG)
+        cmd = make_market_command(builder)
+        result = cmd("IQ21835", "IQ_CLOSEPRICE", freq="Q", num_periods=20)
+        assert result.startswith("=SPGRangeV(")
+
+
+class TestMakeHoldingsCommand:
+    def test_ciq_builder_holdings(self):
+        builder = get_builder(FormulaDialect.CIQ)
+        cmd = make_holdings_command(builder)
+        result = cmd("IQ21835", "IQ_HOLDER_NAME", "03/15/2024", data_item_label="Holder")
+        assert result.startswith("=CIQRANGE(")
+        assert '"Holder"' in result
+
+    def test_spg_builder_holdings(self):
+        builder = get_builder(FormulaDialect.SPG)
+        cmd = make_holdings_command(builder)
+        result = cmd("IQ21835", "IQ_HOLDER_NAME", "03/15/2024")
+        assert result.startswith("=SPGRangeV(")
+
+
+class TestMakeIdCommand:
+    def test_ciq_builder_id(self):
+        builder = get_builder(FormulaDialect.CIQ)
+        cmd = make_id_command(builder)
+        result = cmd("MSFT")
+        assert result == '=CIQ("MSFT","IQ_COMPANY_ID")'
+
+    def test_spg_builder_id(self):
+        builder = get_builder(FormulaDialect.SPG)
+        cmd = make_id_command(builder)
+        result = cmd("MSFT")
+        assert result == '=SPG("MSFT", "IQ_COMPANY_ID_QUICK_MATCH")'
+
+
+class TestMakeNameCommand:
+    def test_ciq_builder_name(self):
+        builder = get_builder(FormulaDialect.CIQ)
+        cmd = make_name_command(builder)
+        result = cmd("AAPL")
+        assert result == '=CIQ("AAPL","IQ_COMPANY_NAME")'
+
+    def test_spg_builder_name(self):
+        builder = get_builder(FormulaDialect.SPG)
+        cmd = make_name_command(builder)
+        result = cmd("AAPL")
+        assert result == '=SPG("AAPL", "IQ_COMPANY_NAME_QUICK_MATCH")'
+
+
+# ============================================================
+# Legacy command backward compatibility
+# ============================================================
+
+class TestLegacyCommandsUnchanged:
+    def test_financial_data_command(self):
+        result = financial_data_command("IQ21835", "IQ_TOTAL_REV", freq="Q", num_periods=80, data_item_label="Sales")
+        assert result == '=CIQRANGE("IQ21835", "IQ_TOTAL_REV", IQ_FQ - 80, , , , , , "Sales")'
+
+    def test_id_command(self):
+        result = id_command("MSFT")
+        assert result == '=CIQRANGEA("MSFT","IQ_COMPANY_ID_QUICK_MATCH",1,1)'
+
+    def test_name_command(self):
+        result = name_command("AAPL")
+        assert result == '=CIQRANGEA("AAPL","IQ_COMPANY_NAME_QUICK_MATCH",1,1)'
+
+
+# ============================================================
+# Config -> Builder -> Command end-to-end
+# ============================================================
+
+class TestEndToEndConfigToCommand:
+    def test_default_config_produces_ciq(self):
+        config = CapiqConfig()
+        dialect = config.resolve_dialect()
+        builder = get_builder(dialect)
+        cmd = make_financial_command(builder)
+        result = cmd("IQ21835", "IQ_TOTAL_REV")
+        assert result.startswith("=CIQRANGE(")
+
+    def test_spg_config_produces_spg(self):
+        config = CapiqConfig(formula_dialect=FormulaDialect.SPG)
+        dialect = config.resolve_dialect()
+        builder = get_builder(dialect)
+        cmd = make_financial_command(builder)
+        result = cmd("IQ21835", "IQ_TOTAL_REV")
+        assert result.startswith("=SPGRangeV(")
+
+    def test_auto_no_ciq_compat_produces_spg(self):
+        config = CapiqConfig(formula_dialect=FormulaDialect.AUTO)
+        dialect = config.resolve_dialect(ciq_compat_available=False)
+        builder = get_builder(dialect)
+        cmd = make_financial_command(builder)
+        result = cmd("IQ21835", "IQ_TOTAL_REV")
+        assert result.startswith("=SPGRangeV(")
+
+    def test_env_config_to_builder(self, monkeypatch):
+        monkeypatch.setenv("CAPIQ_FORMULA_DIALECT", "spg")
+        config = CapiqConfig.from_env()
+        dialect = config.resolve_dialect()
+        builder = get_builder(dialect)
+        assert builder.dialect_name() == "spg"
+
+
+# ============================================================
+# Refresh engine token coverage
+# ============================================================
+
+class TestRefreshTokens:
+    def test_pending_tokens_lowercase(self):
+        from capiq_excel.refresh.engine import PENDING_TOKENS
+        for tok in PENDING_TOKENS:
+            assert tok == tok.lower()
+
+    def test_error_tokens_lowercase(self):
+        from capiq_excel.refresh.engine import HARD_ERROR_TOKENS, LEGACY_ERROR_TOKENS
+        for tok in HARD_ERROR_TOKENS | LEGACY_ERROR_TOKENS:
+            assert tok == tok.lower()
+
+    def test_all_error_tokens_is_union(self):
+        from capiq_excel.refresh.engine import ALL_ERROR_TOKENS, HARD_ERROR_TOKENS, LEGACY_ERROR_TOKENS
+        assert ALL_ERROR_TOKENS == HARD_ERROR_TOKENS | LEGACY_ERROR_TOKENS
+
+
+# ============================================================
+# CLI module importability
+# ============================================================
+
+class TestCLIImport:
+    def test_cli_module_imports(self):
+        from capiq_excel.cli import main
+        assert callable(main)
+
+    def test_cli_status_command(self):
+        from capiq_excel.cli import main
+        # --help or status should not raise
+        result = main(["status"])
+        assert result == 0

--- a/test_dsgx_chart.py
+++ b/test_dsgx_chart.py
@@ -1,0 +1,171 @@
+"""Download daily DSGX close prices via Capital IQ and plot a 12-month chart."""
+import time
+import os
+import re
+import subprocess
+import win32com.client
+import pythoncom
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from openpyxl import Workbook
+
+pythoncom.CoInitialize()
+
+# ── Config ──────────────────────────────────────────────────────────────
+TICKER = "DSGX"
+CIQ_ID = "IQ35352"  # Resolved CIQ ID for Descartes Systems Group
+BEGIN_DATE = "02/25/2025"
+END_DATE = "02/25/2026"
+CHART_PATH = os.path.abspath("dsgx_stock_chart.png")
+
+# Regex to extract date from expanded CIQ formula: =CIQ("id", "metric", "date")
+CIQ_FORMULA_DATE_RE = re.compile(r'=CIQ\("[^"]+",\s*"[^"]+",\s*"([^"]+)"\)')
+
+# ── Step 1: Create workbook with CIQRANGE formula ───────────────────────
+print(f"Creating workbook for {TICKER} ({CIQ_ID}) daily close prices...")
+print(f"Date range: {BEGIN_DATE} to {END_DATE}")
+
+wb = Workbook()
+ws = wb.active
+ws.title = "Sheet"
+
+# Column A: Date column (financial data style) — label only
+ws['A1'] = "Date"
+
+# Column B: Close price via CIQRANGE market data formula (legacy syntax)
+# This will expand vertically, with each cell becoming =CIQ(id, metric, date)
+formula = f'=CIQRANGE("{CIQ_ID}", "IQ_CLOSEPRICE", "{BEGIN_DATE}", "{END_DATE}", , , , , "IQ_CLOSEPRICE")'
+ws['B1'] = formula
+print(f"Formula: {formula}")
+
+test_path = os.path.abspath("dsgx_daily_prices.xlsx")
+wb.save(test_path)
+
+# ── Step 2: Launch Excel via subprocess (required for add-in initialization) ──
+print("\nKilling any existing Excel instances...")
+os.system('taskkill /f /im excel.exe 2>NUL')
+time.sleep(5)
+
+excel_exe = r"C:\Program Files\Microsoft Office\root\Office16\EXCEL.EXE"
+print(f"Launching Excel with workbook...")
+proc = subprocess.Popen([excel_exe, test_path])
+print("Waiting 30s for add-ins to initialize...")
+time.sleep(30)
+
+# Connect via Running Object Table
+excel = win32com.client.GetActiveObject("Excel.Application")
+print(f"Connected to Excel {excel.Version}")
+
+# ── Step 3: Trigger refresh and wait ─────────────────────────────────────
+print("\nTriggering RefreshSheet...")
+try:
+    excel.Run("SNLXLAddin.xla!RefreshSheet")
+    print("RefreshSheet executed successfully")
+except Exception as e:
+    print(f"RefreshSheet warning: {e}")
+
+# Poll for completion
+MAX_WAIT = 180  # 3 minutes
+POLL_INTERVAL = 5
+ws_com = excel.ActiveWorkbook.Sheets(1)
+
+print(f"Waiting for formulas to evaluate (max {MAX_WAIT}s)...")
+start = time.monotonic()
+last_count = 0
+
+while True:
+    elapsed = time.monotonic() - start
+    if elapsed > MAX_WAIT:
+        print(f"  Timeout after {MAX_WAIT}s")
+        break
+
+    # Count populated data cells in column B (starting from row 2)
+    data_count = 0
+    pending = False
+    for row in range(2, 400):
+        val = ws_com.Cells(row, 2).Value
+        if val is None:
+            break
+        data_count += 1
+        if isinstance(val, str) and val.upper() in ('#PEND', '#REFRESH', 'CIQRANGE'):
+            pending = True
+
+    if data_count != last_count:
+        print(f"  {elapsed:.0f}s: {data_count} data rows, pending={pending}")
+        last_count = data_count
+
+    if data_count > 10 and not pending:
+        # Check a sample cell to confirm it has a real value
+        sample = ws_com.Cells(10, 2).Value
+        if isinstance(sample, (int, float)) and sample > 0:
+            print(f"  Data ready! {data_count} rows after {elapsed:.0f}s")
+            break
+
+    time.sleep(POLL_INTERVAL)
+
+# ── Step 4: Extract data (dates from formulas, values from cells) ────────
+print("\nExtracting data...")
+dates = []
+prices = []
+
+for row in range(2, 500):
+    val = ws_com.Cells(row, 2).Value
+    if val is None:
+        break
+
+    # Get the formula — in compat mode, CIQRANGE expands to individual CIQ() calls
+    try:
+        formula = ws_com.Cells(row, 2).Formula
+    except:
+        formula = ""
+
+    # Extract date from formula
+    date_match = CIQ_FORMULA_DATE_RE.match(formula)
+    if date_match:
+        date_str = date_match.group(1)
+    else:
+        date_str = None
+
+    if isinstance(val, (int, float)) and date_str:
+        dates.append(date_str)
+        prices.append(float(val))
+    elif isinstance(val, str) and val.startswith('#'):
+        print(f"  Row {row}: error = {val}")
+
+print(f"Extracted {len(prices)} data points")
+
+# ── Step 5: Close Excel and clean up ─────────────────────────────────────
+excel.ActiveWorkbook.Close(SaveChanges=False)
+excel.Quit()
+os.remove(test_path)
+
+# ── Step 6: Build DataFrame and plot ─────────────────────────────────────
+if len(prices) < 5:
+    print("ERROR: Not enough data points for a chart")
+    exit(1)
+
+df = pd.DataFrame({"Date": pd.to_datetime(dates), "Close": prices})
+df = df.sort_values("Date")
+df = df.set_index("Date")
+
+print(f"\nData summary:")
+print(f"  Period: {df.index[0].date()} to {df.index[-1].date()}")
+print(f"  Points: {len(df)}")
+print(f"  Min:    ${df['Close'].min():.2f}")
+print(f"  Max:    ${df['Close'].max():.2f}")
+print(f"  Latest: ${df['Close'].iloc[-1]:.2f}")
+
+# Plot
+fig, ax = plt.subplots(figsize=(14, 6))
+ax.plot(df.index, df["Close"], color="#1f77b4", linewidth=1.2)
+ax.fill_between(df.index, df["Close"], alpha=0.1, color="#1f77b4")
+ax.set_title(f"Descartes Systems Group (DSGX) — Daily Close Price", fontsize=14, fontweight="bold")
+ax.set_ylabel("Price (USD)", fontsize=12)
+ax.set_xlabel("")
+ax.grid(True, alpha=0.3)
+ax.tick_params(axis='x', rotation=30)
+fig.tight_layout()
+fig.savefig(CHART_PATH, dpi=150, bbox_inches="tight")
+print(f"\nChart saved to: {CHART_PATH}")


### PR DESCRIPTION
## Summary

- Add multi-dialect formula builder system supporting CIQ (legacy), SPG (Pro), and SNL (Pro) formula families with a shared `QuerySpec` abstraction
- Add runtime add-in detection via COM enumeration and Windows registry, with automatic dialect resolution
- Add Pro refresh engine using corrected VBA macros (`SNLxlAddin.xla!RefreshSheet`) with expanded error/pending token detection
- Add `CapiqConfig` with `FormulaDialect`, `AddinMode`, and `RefreshScope` enums for explicit configuration
- Add CLI with `status`, `detect-addins`, `download`, and `doctor` subcommands
- Fix CIQ ID lookup to use `CIQ()` instead of `CIQRANGEA()` (which doesn't work in Pro CIQ compat mode)
- Fix pandas 3.x deprecation warnings (`Q`→`QE`, `Y`→`YE` offset aliases)
- All existing behavior preserved when no config is provided (backward compatible)

Verified end-to-end: downloaded 252 daily DSGX close prices from Capital IQ Pro's CIQ compat layer. 73 unit tests passing.

### Key findings from live testing

- Excel **must** be launched via subprocess (not `Dispatch()`) for UDFs to register
- In Pro CIQ compat mode: `CIQ()` and `CIQRANGE()` work; `CIQRANGEA()` does NOT
- VBA refresh macros use `SNLxlAddin.xla!` prefix (not `SNL.Clients.Office.Excel.Functions.`)
- CIQ compat registry key `DisableCIQUDF=0` means CIQ is enabled (inverted logic)

## Test plan

- [x] 73 unit tests passing (`test_config.py`, `test_formulas.py`, `test_smoke.py`)
- [x] End-to-end integration test downloading DSGX daily stock prices via CIQ compat
- [ ] Test with legacy CIQ plugin (without Pro) to verify backward compatibility
- [ ] Test SPG native dialect with correct metric name mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)